### PR TITLE
feat: application of final fixes and updates to the connector

### DIFF
--- a/zicb-zm-core-connector/src/api-spec/api.oas2.yml
+++ b/zicb-zm-core-connector/src/api-spec/api.oas2.yml
@@ -1,46 +1,33 @@
 openapi: 3.0.1
 info:
   title: Mojaloop SDK Outbound Scheme Adapter API
-  description: >
+  description: |
     Specification for the Mojaloop SDK Scheme Adapter Outbound Transfers API
 
+    This API can be used by DFSP backends to simplify the process of sending funds to other parties within a Mojaloop scheme.
 
-    This API can be used by DFSP backends to simplify the process of sending
-    funds to other parties within a Mojaloop scheme.
+    Please see other documentation on https://github.com/mojaloop/sdk-scheme-adapter for more information.
 
-
-    Please see other documentation on
-    https://github.com/mojaloop/sdk-scheme-adapter for more information.
-
-
-    **Note on terminology:** The term "Switch" is equal to the term "Hub", and
-    the term "FSP" is equal to the term "DFSP".
+    **Note on terminology:** The term "Switch" is equal to the term "Hub", and the term "FSP" is equal to the term "DFSP".
   license:
     name: Apache License Version 2.0, January 2004
     url: https://github.com/mojaloop/documentation/blob/main/LICENSE.md
-  version: 1.0.0
+  version: 2.1.0
 paths:
   /:
     get:
       summary: Health check endpoint
-      description: >-
-        This endpoint allows a user of the SDK scheme adapter to check the
-        outbound transfers service is listening.
+      description: This endpoint allows a user of the SDK scheme adapter to check the outbound transfers service is listening.
       tags:
         - Health
       responses:
         '200':
-          description: >-
-            Returns empty body if the scheme adapter outbound transfers service
-            is running.
+          description: Returns empty body if the scheme adapter outbound transfers service is running.
   /accounts:
     post:
       summary: Create accounts on the Account Lookup Service
-      description: >-
-        The HTTP request `POST /accounts` is used to create account information
-        on the Account Lookup Service (ALS) regarding the provided list of
-        identities.
-
+      description: |-
+        The HTTP request `POST /accounts` is used to create account information on the Account Lookup Service (ALS) regarding the provided list of identities.
 
         Caller DFSP is used as the account source FSP information
       tags:
@@ -64,9 +51,8 @@ paths:
   /bulkQuotes:
     post:
       summary: Request bulk quotes for the provided financial transactions
-      description: >
-        The HTTP request `POST /bulkQuotes` is used to request a bulk quote to
-        fascilitate funds transfer from payer DFSP to payees' DFSP.
+      description: |
+        The HTTP request `POST /bulkQuotes` is used to request a bulk quote to fascilitate funds transfer from payer DFSP to payees' DFSP.
       tags:
         - BulkQuotes
       requestBody:
@@ -88,11 +74,7 @@ paths:
   /bulkQuotes/{bulkQuoteId}:
     get:
       summary: Retrieves information for a specific bulk quote
-      description: >-
-        The HTTP request `GET /bulkQuotes/{bulktQuoteId}` is used to get
-        information regarding a bulk quote created or requested earlier. The
-        `{bulkQuoteId}` in the URI should contain the `bulkQuoteId` that was
-        used for the creation of the bulk quote.
+      description: The HTTP request `GET /bulkQuotes/{bulktQuoteId}` is used to get information regarding a bulk quote created or requested earlier. The `{bulkQuoteId}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote.
       tags:
         - BulkQuotes
       parameters:
@@ -113,9 +95,8 @@ paths:
   /bulkTransactions:
     post:
       summary: Sends money from one account to multiple accounts
-      description: >
-        The HTTP request `POST /bulkTransactions` is used to request the
-        movement of funds from payer DFSP to payees' DFSP.
+      description: |
+        The HTTP request `POST /bulkTransactions` is used to request the movement of funds from payer DFSP to payees' DFSP.
       tags:
         - BulkTransactions
       requestBody:
@@ -135,13 +116,7 @@ paths:
   /bulkTransactions/{bulkTransactionId}:
     put:
       summary: Amends the bulk transaction request
-      description: >-
-        The HTTP request `PUT /bulkTransactions/{bulkTransactionId}` is used to
-        amend information regarding a bulk transaction, i.e. when
-        autoAcceptParty or autoAcceptQuote  is false then the payer need to
-        provide confirmation to proceed with further processing of the request.
-        The `{bulkTransactionId}` in the URI should contain the
-        `bulkTransactionId` that was used for the creation of the bulk transfer.
+      description: The HTTP request `PUT /bulkTransactions/{bulkTransactionId}` is used to amend information regarding a bulk transaction, i.e. when autoAcceptParty or autoAcceptQuote  is false then the payer need to provide confirmation to proceed with further processing of the request. The `{bulkTransactionId}` in the URI should contain the `bulkTransactionId` that was used for the creation of the bulk transfer.
       tags:
         - BulkTransactions
       parameters:
@@ -169,9 +144,8 @@ paths:
   /bulkTransfers:
     post:
       summary: Sends money from one account to multiple accounts
-      description: >
-        The HTTP request `POST /bulkTransfers` is used to request the movement
-        of funds from payer DFSP to payees' DFSP.
+      description: |
+        The HTTP request `POST /bulkTransfers` is used to request the movement of funds from payer DFSP to payees' DFSP.
       tags:
         - BulkTransfers
       requestBody:
@@ -191,11 +165,7 @@ paths:
   /bulkTransfers/{bulkTransferId}:
     get:
       summary: Retrieves information for a specific bulk transfer
-      description: >-
-        The HTTP request `GET /bulkTransfers/{bulkTransferId}` is used to get
-        information regarding a bulk transfer created or requested earlier. The
-        `{bulkTransferId}` in the URI should contain the `bulkTransferId` that
-        was used for the creation of the bulk transfer.
+      description: The HTTP request `GET /bulkTransfers/{bulkTransferId}` is used to get information regarding a bulk transfer created or requested earlier. The `{bulkTransferId}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer.
       tags:
         - BulkTransfers
       parameters:
@@ -218,11 +188,7 @@ paths:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
     get:
-      description: >-
-        The HTTP request GET /parties// (or GET /parties///) is used to lookup
-        information regarding the requested Party, defined by ,  and optionally
-        (for example, GET /parties/MSISDN/123456789, or GET
-        /parties/BUSINESS/shoecompany/employee1).
+      description: The HTTP request GET /parties// (or GET /parties///) is used to lookup information regarding the requested Party, defined by ,  and optionally (for example, GET /parties/MSISDN/123456789, or GET /parties/BUSINESS/shoecompany/employee1).
       summary: PartiesByTypeAndID
       tags:
         - parties
@@ -238,11 +204,7 @@ paths:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/SubId'
     get:
-      description: >-
-        The HTTP request GET /parties// (or GET /parties///) is used to lookup
-        information regarding the requested Party, defined by ,  and optionally
-        (for example, GET /parties/MSISDN/123456789, or GET
-        /parties/BUSINESS/shoecompany/employee1).
+      description: The HTTP request GET /parties// (or GET /parties///) is used to lookup information regarding the requested Party, defined by ,  and optionally (for example, GET /parties/MSISDN/123456789, or GET /parties/BUSINESS/shoecompany/employee1).
       summary: PartiesSubIdByTypeAndID
       tags:
         - parties
@@ -274,10 +236,8 @@ paths:
   /requestToPay:
     post:
       summary: Receiver requesting funds from Sender
-      description: >
-        The HTTP request `POST /requestToPay` is used to support Pull Funds
-        pattern where in a receiver can request for funds from the Sender.
-
+      description: |
+        The HTTP request `POST /requestToPay` is used to support Pull Funds pattern where in a receiver can request for funds from the Sender.
         The underlying API has two stages:
 
           1. Party lookup. This facilitates a check by the sending party that the destination party is correct before proceeding with a money movement.
@@ -296,19 +256,11 @@ paths:
           $ref: '#/components/responses/requestToPaySuccess'
   /requestToPay/{transactionRequestId}:
     put:
-      summary: >-
-        Continues a request funds from sender that has paused at the party
-        resolution stage in order to accept or reject party information
-      description: >
-        The HTTP request `PUT /requestToPay/{transactionRequestId}` is used to
-        continue a transfer initiated via the `POST /requestToPay` method that
-        has halted after party lookup stage.
-
-        The request body should contain the "acceptParty" property set to `true`
-        as required to continue the transfer.
-
-        See the description of the `POST /requestToPay` HTTP method for more
-        information on modes of transfer.
+      summary: Continues a request funds from sender that has paused at the party resolution stage in order to accept or reject party information
+      description: |
+        The HTTP request `PUT /requestToPay/{transactionRequestId}` is used to continue a transfer initiated via the `POST /requestToPay` method that has halted after party lookup stage.
+        The request body should contain the "acceptParty" property set to `true` as required to continue the transfer.
+        See the description of the `POST /requestToPay` HTTP method for more information on modes of transfer.
       tags:
         - RequestToPay
       requestBody:
@@ -327,13 +279,9 @@ paths:
           $ref: '#/components/responses/transferTimeout'
   /requestToPayTransfer:
     post:
-      summary: >-
-        Used to trigger funds from customer fsp account to merchant fsp account.
-        This is a follow-up request to requestToPay.
-      description: >
-        The HTTP request `POST /requestToPayTransfer` is used to request the
-        movement of funds from payer DFSP to payee DFSP.
-
+      summary: Used to trigger funds from customer fsp account to merchant fsp account. This is a follow-up request to requestToPay.
+      description: |
+        The HTTP request `POST /requestToPayTransfer` is used to request the movement of funds from payer DFSP to payee DFSP.
         The underlying Mojaloop API has three stages for money transfer:
 
           1. Quotation. This facilitates the exchange of fee information and the construction of a cryptographic "contract" between payee and payer DFSPs before funds are transferred.
@@ -341,30 +289,17 @@ paths:
           3. Transfer. The enactment of the previously agreed "contract"
 
         This method has several modes of operation.
-
-        - If the configuration variable `AUTO_ACCEPT_QUOTES` is set to `"false"`
-        this method will terminate and return the quotation when it has been
-        received from the payee DFSP.
+        - If the configuration variable `AUTO_ACCEPT_QUOTES` is set to `"false"` this method will terminate and return the quotation when it has been received from the payee DFSP.
           If the payee wished to proceed with the otp, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
           The scheme adapter will then proceed with the transfer state.
 
-        - If the configuration variable `AUTO_ACCEPT_OTP` is set to `"false"`
-        this method will terminate and return the otp when it has been received
-        from the payee DFSP.
+        - If the configuration variable `AUTO_ACCEPT_OTP` is set to `"false"` this method will terminate and return the otp when it has been received from the payee DFSP.
           If the payer wished to proceed with the transfer, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
           The scheme adapter will then proceed with the transfer state.
 
-        If the configuration variables `AUTO_ACCEPT_PARTIES` and
-        `AUTO_ACCEPT_QUOTES` are both set to `"true"` this method will block
-        until all three transfer stages are complete. Upon completion it will
-        return the entire set of transfer details received during the operation.
+        If the configuration variables `AUTO_ACCEPT_PARTIES` and `AUTO_ACCEPT_QUOTES` are both set to `"true"` this method will block until all three transfer stages are complete. Upon completion it will return the entire set of transfer details received during the operation.
 
-
-        Combinations of settings for `AUTO_ACCEPT...` configuration variables
-        allow the scheme adapter user to decide which mode of operation best
-        suits their use cases. i.e. the scheme adapter can be configured to
-        "break" the three stage transfer at these points in order to execute
-        backend logic such as party verification, quoted fees assessments etc...
+        Combinations of settings for `AUTO_ACCEPT...` configuration variables allow the scheme adapter user to decide which mode of operation best suits their use cases. i.e. the scheme adapter can be configured to "break" the three stage transfer at these points in order to execute backend logic such as party verification, quoted fees assessments etc...
       tags:
         - RequestToPayTransfer
       requestBody:
@@ -385,21 +320,13 @@ paths:
           $ref: '#/components/responses/transferTimeout'
   /requestToPayTransfer/{transactionRequestId}:
     put:
-      summary: >-
-        Continues a transfer that has paused at the otp stage in order to accept
-        or reject quote
-      description: >
-        This request is used to continue a requestToPayTransfer initiated via
-        the `POST /requestToPayTransfer` method that has halted after quotation
-        stage and/or otp stage.
+      summary: Continues a transfer that has paused at the otp stage in order to accept or reject quote
+      description: |
+        This request is used to continue a requestToPayTransfer initiated via the `POST /requestToPayTransfer` method that has halted after quotation stage and/or otp stage.
 
+        The request body should contain either the "acceptOTP" or "acceptQuote" property set to `true` as required to continue the transfer.
 
-        The request body should contain either the "acceptOTP" or "acceptQuote"
-        property set to `true` as required to continue the transfer.
-
-
-        See the description of the `POST /requestToPayTransfer` HTTP method for
-        more information on modes of transfer.
+        See the description of the `POST /requestToPayTransfer` HTTP method for more information on modes of transfer.
       tags:
         - RequestToPayTransferID
       requestBody:
@@ -440,10 +367,8 @@ paths:
   /transfers:
     post:
       summary: Sends money from one account to another
-      description: >
-        The HTTP request `POST /transfers` is used to request the movement of
-        funds from payer DFSP to payee DFSP.
-
+      description: |
+        The HTTP request `POST /transfers` is used to request the movement of funds from payer DFSP to payee DFSP.
         The underlying Mojaloop API has three stages for money transfer:
 
           1. Party lookup. This facilitates a check by the sending party that the destination party is correct before proceeding with a money movement.
@@ -451,30 +376,17 @@ paths:
           3. Transfer. The enactment of the previously agreed "contract"
 
         This method has several modes of operation.
-
-        - If the configuration variables `AUTO_ACCEPT_PARTIES` is set to
-        `"false"` this method will terminate when the payee party has been
-        resolved and return the payee party details.
+        - If the configuration variables `AUTO_ACCEPT_PARTIES` is set to `"false"` this method will terminate when the payee party has been resolved and return the payee party details.
           If the payee wishes to proceed with the transfer, then a subsequent `PUT /transfers/{transferId}` request (accepting the payee party) is required to continue the operation.
           The scheme adapter will then proceed with quotation stage...
 
-        - If the configuration variable `AUTO_ACCEPT_QUOTES` is set to `"false"`
-        this method will terminate and return the quotation when it has been
-        received from the payee DFSP.
+        - If the configuration variable `AUTO_ACCEPT_QUOTES` is set to `"false"` this method will terminate and return the quotation when it has been received from the payee DFSP.
           If the payee wished to proceed with the transfer, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
           The scheme adapter will then proceed with the transfer state.
 
-        If the configuration variables `AUTO_ACCEPT_PARTIES` and
-        `AUTO_ACCEPT_QUOTES` are both set to `"true"` this method will block
-        until all three transfer stages are complete. Upon completion it will
-        return the entire set of transfer details received during the operation.
+        If the configuration variables `AUTO_ACCEPT_PARTIES` and `AUTO_ACCEPT_QUOTES` are both set to `"true"` this method will block until all three transfer stages are complete. Upon completion it will return the entire set of transfer details received during the operation.
 
-
-        Combinations of settings for `AUTO_ACCEPT...` configuration variables
-        allow the scheme adapter user to decide which mode of operation best
-        suits their use cases. i.e. the scheme adapter can be configured to
-        "break" the three stage transfer at these points in order to execute
-        backend logic such as party verification, quoted fees assessments etc...
+        Combinations of settings for `AUTO_ACCEPT...` configuration variables allow the scheme adapter user to decide which mode of operation best suits their use cases. i.e. the scheme adapter can be configured to "break" the three stage transfer at these points in order to execute backend logic such as party verification, quoted fees assessments etc...
       tags:
         - Transfers
       requestBody:
@@ -495,22 +407,13 @@ paths:
           $ref: '#/components/responses/transferTimeout'
   /transfers/{transferId}:
     put:
-      summary: >-
-        Continues a transfer that has paused at the quote stage in order to
-        accept or reject payee party and/or quote
-      description: >
-        The HTTP request `PUT /transfers/{transferId}` is used to continue a
-        transfer initiated via the `POST /transfers` method that has halted
-        after party lookup and/or quotation stage.
+      summary: Continues a transfer that has paused at the quote stage in order to accept or reject payee party and/or quote and/or conversion
+      description: |
+        The HTTP request `PUT /transfers/{transferId}` is used to continue a transfer initiated via the `POST /transfers` method that has halted after party lookup and/or quotation stage and/or currency conversion stage.
 
+        The request body should contain either the "acceptParty" or "acceptQuote" or "acceptConversion" property set to `true` as required to continue the transfer.
 
-        The request body should contain either the "acceptParty" or
-        "acceptQuote" property set to `true` as required to continue the
-        transfer.
-
-
-        See the description of the `POST /transfers` HTTP method for more
-        information on modes of transfer.
+        See the description of the `POST /transfers` HTTP method for more information on modes of transfer.
       tags:
         - Transfers
       requestBody:
@@ -520,6 +423,7 @@ paths:
               oneOf:
                 - $ref: '#/components/schemas/transferContinuationAcceptParty'
                 - $ref: '#/components/schemas/transferContinuationAcceptQuote'
+                - $ref: '#/components/schemas/transferContinuationAcceptConversion'
       parameters:
         - $ref: '#/components/parameters/transferId'
       responses:
@@ -531,11 +435,7 @@ paths:
           $ref: '#/components/responses/transferTimeout'
     get:
       summary: Retrieves information for a specific transfer
-      description: >-
-        The HTTP request `GET /transfers/{transferId}` is used to get
-        information regarding a transfer created or requested earlier. The
-        `{transferId}` in the URI should contain the `transferId` that was used
-        for the creation of the transfer.
+      description: The HTTP request `GET /transfers/{transferId}` is used to get information regarding a transfer created or requested earlier. The `{transferId}` in the URI should contain the `transferId` that was used for the creation of the transfer.
       tags:
         - Transfers
       parameters:
@@ -553,6 +453,87 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/errorResponse'
+  /services/FXP:
+    get:
+      description: The HTTP request `GET /services/FXP` is used to request information about the participants in a scheme who offer currency conversion services.
+      summary: Obtain a list of the DFSPs in the scheme who provide FXP service
+      tags:
+        - servicesFXP
+      operationId: ServicesFXPGet
+      responses:
+        '200':
+          $ref: '#/components/responses/servicesFXPSucess'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  /services/FXP/{SourceCurrency}/{TargetCurrency}:
+    get:
+      description: The HTTP request `GET /services/FXP/{SourceCurrency}/{TargetCurrency}` is used to request information about the participants in a scheme who offer currency conversion services in a particular currency corridor. The required corridor is specified by giving the ISO 4217 currency code for the SourceCurrency and the TargetCurrency.
+      summary: Obtain a list of the DFSPs in the scheme who provide FXP service
+      tags:
+        - servicesFXP
+      operationId: ServicesFXPSourceCurrencyTargetCurrencyGet
+      parameters:
+        - $ref: '#/components/parameters/SourceCurrency'
+        - $ref: '#/components/parameters/TargetCurrency'
+      responses:
+        '200':
+          $ref: '#/components/responses/servicesFXPSucess'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  /fxQuotes:
+    post:
+      description: The HTTP request `POST /fxQuotes` is used to ask to provide a quotation for a currency conversion.
+      summary: Calculate FX quote
+      tags:
+        - Fx
+      operationId: FxQuotesPost
+      requestBody:
+        description: Details of the FX quote request.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FxQuotesPostOutboundRequest'
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FxQuotesPostOutboundResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  /fxTransfers:
+    post:
+      description: The HTTP request `POST /fxTransfers` is used to ask to confirm the execution of an agreed currency conversion.
+      summary: Perform FX transfer
+      tags:
+        - Fx
+      operationId: FxTransfersPost
+      requestBody:
+        description: Details of the FX transfer request.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FxTransfersPostOutboundRequest'
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FxTransfersPostOutboundResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
 components:
   schemas:
     PartyIdType:
@@ -567,52 +548,16 @@ components:
         - ACCOUNT_ID
         - IBAN
         - ALIAS
-      description: >-
+      description: |-
         Below are the allowed values for the enumeration.
-
-        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory
-        Number, that is, the phone number) is used as reference to a
-        participant. The MSISDN identifier should be in international format
-        according to the [ITU-T E.164
-        standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the
-        MSISDN may be prefixed by a single plus sign, indicating the
-        international prefix.
-
-        - EMAIL - An email is used as reference to a participant. The format of
-        the email should be according to the informational [RFC
-        3696](https://tools.ietf.org/html/rfc3696).
-
-        - PERSONAL_ID - A personal identifier is used as reference to a
-        participant. Examples of personal identification are passport number,
-        birth certificate number, and national registration number. The
-        identifier number is added in the PartyIdentifier element. The personal
-        identifier type is added in the PartySubIdOrType element.
-
-        - BUSINESS - A specific Business (for example, an organization or a
-        company) is used as reference to a participant. The BUSINESS identifier
-        can be in any format. To make a transaction connected to a specific
-        username or bill number in a Business, the PartySubIdOrType element
-        should be used.
-
-        - DEVICE - A specific device (for example, a POS or ATM) ID connected to
-        a specific business or organization is used as reference to a Party. For
-        referencing a specific device under a specific business or organization,
-        use the PartySubIdOrType element.
-
-        - ACCOUNT_ID - A bank account number or FSP account ID should be used as
-        reference to a participant. The ACCOUNT_ID identifier can be in any
-        format, as formats can greatly differ depending on country and FSP.
-
-        - IBAN - A bank account number or FSP account ID is used as reference to
-        a participant. The IBAN identifier can consist of up to 34 alphanumeric
-        characters and should be entered without whitespace.
-
-        - ALIAS An alias is used as reference to a participant. The alias should
-        be created in the FSP as an alternative reference to an account owner.
-        Another example of an alias is a username in the FSP system. The ALIAS
-        identifier can be in any format. It is also possible to use the
-        PartySubIdOrType element for identifying an account under an Alias
-        defined by the PartyIdentifier.
+        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the [ITU-T E.164 standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix.
+        - EMAIL - An email is used as reference to a participant. The format of the email should be according to the informational [RFC 3696](https://tools.ietf.org/html/rfc3696).
+        - PERSONAL_ID - A personal identifier is used as reference to a participant. Examples of personal identification are passport number, birth certificate number, and national registration number. The identifier number is added in the PartyIdentifier element. The personal identifier type is added in the PartySubIdOrType element.
+        - BUSINESS - A specific Business (for example, an organization or a company) is used as reference to a participant. The BUSINESS identifier can be in any format. To make a transaction connected to a specific username or bill number in a Business, the PartySubIdOrType element should be used.
+        - DEVICE - A specific device (for example, a POS or ATM) ID connected to a specific business or organization is used as reference to a Party. For referencing a specific device under a specific business or organization, use the PartySubIdOrType element.
+        - ACCOUNT_ID - A bank account number or FSP account ID should be used as reference to a participant. The ACCOUNT_ID identifier can be in any format, as formats can greatly differ depending on country and FSP.
+        - IBAN - A bank account number or FSP account ID is used as reference to a participant. The IBAN identifier can consist of up to 34 alphanumeric characters and should be entered without whitespace.
+        - ALIAS An alias is used as reference to a participant. The alias should be created in the FSP as an alternative reference to an account owner. Another example of an alias is a username in the FSP system. The ALIAS identifier can be in any format. It is also possible to use the PartySubIdOrType element for identifying an account under an Alias defined by the PartyIdentifier.
     PartyIdentifier:
       title: PartyIdentifier
       type: string
@@ -625,21 +570,15 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      description: >-
-        Either a sub-identifier of a PartyIdentifier, or a sub-type of the
-        PartyIdType, normally a PersonalIdentifierType.
+      description: Either a sub-identifier of a PartyIdentifier, or a sub-type of the PartyIdType, normally a PersonalIdentifierType.
     Currency:
       title: Currency
-      description: >-
-        The currency codes defined in [ISO
-        4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter
-        alphabetic codes are used as the standard naming representation for
-        currencies.
+      description: The currency codes defined in [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter alphabetic codes are used as the standard naming representation for currencies.
       type: string
       minLength: 3
       maxLength: 3
       enum:
-        - AED
+        - ZMW
         - AFN
         - ALL
         - AMD
@@ -801,7 +740,7 @@ components:
         - XXX
         - YER
         - ZAR
-        - ZMW
+        - AED
         - ZWD
     accountsRequest:
       type: array
@@ -823,22 +762,17 @@ components:
     CorrelationId:
       title: CorrelationId
       type: string
-      pattern: >-
-        ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
-      description: >-
-        Identifier that correlates all messages of the same sequence. The API
-        data type UUID (Universally Unique Identifier) is a JSON String in
-        canonical format, conforming to [RFC
-        4122](https://tools.ietf.org/html/rfc4122), that is restricted by a
-        regular expression for interoperability reasons. A UUID is always 36
-        characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+      pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$|^[0-9A-HJKMNP-TV-Z]{26}$
+      description: Identifier that correlates all messages of the same sequence. The supported identifiers formats are for lowercase [UUID](https://datatracker.ietf.org/doc/html/rfc9562) and uppercase [ULID](https://github.com/ulid/spec)
       example: b51ec534-ee48-4575-b6a9-ead2955b8069
     errorResponse:
       type: object
       properties:
         statusCode:
           type: string
-          description: Error code as string.
+          description: |
+            Backend error code from FSP. Ideally, statusCode is FSPIOP conforming. SDK will use status code to retrieve an FSPIOP error with the same code.
+            Otherwise, a suitable generic FSPIOP will be used with the errorResponse in the FSPIOP error message.
         message:
           type: string
           description: Error message text.
@@ -867,14 +801,7 @@ components:
       title: ErrorCode
       type: string
       pattern: ^[1-9]\d{3}$
-      description: >-
-        The API data type ErrorCode is a JSON String of four characters,
-        consisting of digits only. Negative numbers are not allowed. A leading
-        zero is not allowed. Each error code in the API is a four-digit number,
-        for example, 1234, where the first number (1 in the example) represents
-        the high-level error category, the second number (2 in the example)
-        represents the low-level error category, and the last two numbers (34 in
-        the example) represent the specific error.
+      description: The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represent the specific error.
       example: '5100'
     ErrorDescription:
       title: ErrorDescription
@@ -909,9 +836,7 @@ components:
     ExtensionList:
       title: ExtensionList
       type: object
-      description: >-
-        Data model for the complex type ExtensionList. An optional list of
-        extensions, specific to deployment.
+      description: Data model for the complex type ExtensionList. An optional list of extensions, specific to deployment.
       properties:
         extension:
           type: array
@@ -943,16 +868,11 @@ components:
           $ref: '#/components/schemas/ErrorInformation'
     transferError:
       type: object
-      description: >-
-        This may be a Mojaloop API error returned from another entity in the
-        scheme or an object representing other types of error e.g. exceptions
-        that may occur inside the scheme adapter.
+      description: This object represents a Mojaloop API error received at any time during the transfer process
       properties:
         httpStatusCode:
           type: integer
-          description: >-
-            The HTTP status code returned to the caller. This is the same as the
-            actual HTTP status code returned with the response.
+          description: The HTTP status code returned to the caller. This is the same as the actual HTTP status code returned with the response.
         mojaloopError:
           $ref: '#/components/schemas/mojaloopError'
     accountsResponse:
@@ -1007,29 +927,18 @@ components:
       title: Name
       type: string
       pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: >-
-        The API data type Name is a JSON String, restricted by a regular
-        expression to avoid characters which are generally not used in a name.
+      description: |-
+        The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally not used in a name.
 
+        Regular Expression - The regular expression for restricting the Name type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,) and space characters ( ).
 
-        Regular Expression - The regular expression for restricting the Name
-        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
-        string consisting of whitespace only, all Unicode characters are
-        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
-        and space characters ( ).
-
-
-        **Note:** In some programming languages, Unicode support must be
-        specifically enabled. For example, if Java is used, the flag
-        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+        **Note:** In some programming languages, Unicode support must be specifically enabled. For example, if Java is used, the flag UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
     FirstName:
       title: FirstName
       type: string
       minLength: 1
       maxLength: 128
-      pattern: >-
-        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
-        .,''-]{1,128}$
+      pattern: ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$
       description: First name of the Party (Name Type).
       example: Henrik
     MiddleName:
@@ -1037,9 +946,7 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      pattern: >-
-        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
-        .,''-]{1,128}$
+      pattern: ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$
       description: Middle name of the Party (Name Type).
       example: Johannes
     LastName:
@@ -1047,32 +954,60 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      pattern: >-
-        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
-        .,''-]{1,128}$
+      pattern: ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$
       description: Last name of the Party (Name Type).
       example: Karlsson
     DateOfBirth:
       title: DateofBirth (type Date)
       type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
       description: Date of Birth of the Party.
       example: '1966-06-16'
     MerchantClassificationCode:
       title: MerchantClassificationCode
       type: string
       pattern: ^[\d]{1,4}$
-      description: >-
-        A limited set of pre-defined numbers. This list would be a limited set
-        of numbers identifying a set of popular merchant types like School Fees,
-        Pubs and Restaurants, Groceries, etc.
+      description: A limited set of pre-defined numbers. This list would be a limited set of numbers identifying a set of popular merchant types like School Fees, Pubs and Restaurants, Groceries, etc.
     FspId:
       title: FspId
       type: string
       minLength: 1
       maxLength: 32
       description: FSP identifier.
+    KYCInformation:
+      title: KYCInformation
+      type: string
+      minLength: 1
+      maxLength: 2048
+      description: KYC information for the party in a form mandated by an individual scheme.
+      example: |-
+        {
+            "metadata": {
+                "format": "JSON",
+                "version": "1.0",
+                "description": "Data containing KYC Information"
+            },
+            "data": {
+                "name": "John Doe",
+                "dob": "1980-05-15",
+                "gender": "Male",
+                "address": "123 Main Street, Anytown, USA",
+                "email": "johndoe@example.com",
+                "phone": "+1 555-123-4567",
+                "nationality": "US",
+                "passport_number": "AB1234567",
+                "issue_date": "2010-02-20",
+                "expiry_date": "2025-02-20",
+                "bank_account_number": "1234567890",
+                "bank_name": "Example Bank",
+                "employer": "ABC Company",
+                "occupation": "Software Engineer",
+                "income": "$80,000 per year",
+                "marital_status": "Single",
+                "dependents": 0,
+                "risk_level": "Low"
+            }
+        }
     extensionListEmptiable:
       type: array
       items:
@@ -1107,6 +1042,15 @@ components:
           $ref: '#/components/schemas/MerchantClassificationCode'
         fspId:
           $ref: '#/components/schemas/FspId'
+        supportedCurrencies:
+          type: array
+          description: Currencies in which the party can receive funds.
+          items:
+            $ref: '#/components/schemas/Currency'
+          minItems: 0
+          maxItems: 16
+        kycInformation:
+          $ref: '#/components/schemas/KYCInformation'
         extensionList:
           $ref: '#/components/schemas/extensionListEmptiable'
     AmountType:
@@ -1115,26 +1059,16 @@ components:
       enum:
         - SEND
         - RECEIVE
-      description: >-
+      description: |-
         Below are the allowed values for the enumeration AmountType.
-
-        - SEND - Amount the Payer would like to send, that is, the amount that
-        should be withdrawn from the Payer account including any fees.
-
-        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
-        the amount that should be sent to the receiver exclusive of any fees.
+        - SEND - Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees.
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver exclusive of any fees.
       example: RECEIVE
     Amount:
       title: Amount
       type: string
       pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
-      description: >-
-        The API data type Amount is a JSON String in a canonical format that is
-        restricted by a regular expression for interoperability reasons. This
-        pattern does not allow any trailing zeroes at all, but allows an amount
-        without a minor currency unit. It also only allows four digits in the
-        minor currency unit; a negative value is not allowed. Using more than 18
-        digits in the major currency unit is not allowed.
+      description: The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.
       example: '123.45'
     transferTransactionType:
       title: transferTransactionType
@@ -1146,9 +1080,7 @@ components:
       title: TransactionSubScenario
       type: string
       pattern: ^[A-Z_]{1,32}$
-      description: >-
-        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
-        Type).
+      description: Possible sub-scenario, defined locally within the scheme (UndefinedEnum Type).
       example: LOCALLY_DEFINED_SUBSCENARIO
     Note:
       title: Note
@@ -1196,9 +1128,7 @@ components:
       properties:
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         bulkQuoteId:
           $ref: '#/components/schemas/CorrelationId'
         from:
@@ -1215,17 +1145,8 @@ components:
     DateTime:
       title: DateTime
       type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
-      description: >-
-        The API data type DateTime is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons. The
-        format is according to [ISO
-        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
-        in a combined date, time and time zone format. A more readable version
-        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
-        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
-        indicates Zulu time zone, same as UTC).
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons. The format is according to [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed in a combined date, time and time zone format. A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z indicates Zulu time zone, same as UTC).
       example: '2016-05-24T08:38:08.699-04:00'
     bulkTransferStatus:
       type: string
@@ -1244,30 +1165,38 @@ components:
       required:
         - currency
         - amount
+    fspMoney:
+      title: Money
+      type: object
+      description: Data model for the complex type Money.
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          title: Amount
+          type: string
+          pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+          description: The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.
+          example: '0'
+      required:
+        - currency
+        - amount
     Latitude:
       title: Latitude
       type: string
-      pattern: >-
-        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: >-
-        The API data type Latitude is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons.
+      pattern: ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: The API data type Latitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
       example: '+45.4215'
     Longitude:
       title: Longitude
       type: string
-      pattern: >-
-        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: >-
-        The API data type Longitude is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons.
+      pattern: ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: The API data type Longitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
       example: '+75.6972'
     GeoCode:
       title: GeoCode
       type: object
-      description: >-
-        Data model for the complex type GeoCode. Indicates the geographic
-        location from where the transaction was initiated.
+      description: Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.
       properties:
         latitude:
           $ref: '#/components/schemas/Latitude'
@@ -1283,8 +1212,7 @@ components:
       minLength: 1
       maxLength: 32768
       description: Information for recipient (transport layer information).
-      example: >-
-        AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+      example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
     IlpCondition:
       title: IlpCondition
       type: string
@@ -1293,15 +1221,11 @@ components:
       description: Condition that must be attached to the transfer by the Payer.
     quoteError:
       type: object
-      description: >-
-        This object represents a Mojaloop API error received at any time during
-        the quote process
+      description: This object represents a Mojaloop API error received at any time during the quote process
       properties:
         httpStatusCode:
           type: integer
-          description: >-
-            The HTTP status code returned to the caller. This is the same as the
-            actual HTTP status code returned with the response.
+          description: The HTTP status code returned to the caller. This is the same as the actual HTTP status code returned with the response.
         mojaloopError:
           $ref: '#/components/schemas/mojaloopError'
     individualQuoteResult:
@@ -1316,7 +1240,7 @@ components:
         payeeFspFee:
           $ref: '#/components/schemas/Money'
         payeeFspCommission:
-          $ref: '#/components/schemas/Money'
+          $ref: '#/components/schemas/fspMoney'
         geoCode:
           $ref: '#/components/schemas/GeoCode'
         ilpPacket:
@@ -1341,9 +1265,7 @@ components:
           $ref: '#/components/schemas/CorrelationId'
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         expiration:
           $ref: '#/components/schemas/DateTime'
         extensionList:
@@ -1430,42 +1352,27 @@ components:
         - bulkExpiration
       properties:
         onlyValidateParty:
-          description: >-
-            Set to true if only party validation is required.  This means the
-            quotes and transfers will not run. This is useful for only party
-            resolution.
+          description: Set to true if only party validation is required.  This means the quotes and transfers will not run. This is useful for only party resolution.
           type: boolean
         autoAcceptParty:
           $ref: '#/components/schemas/autoAcceptPartyOption'
         autoAcceptQuote:
-          description: >-
-            Set to true if the quote response is accepted without confirmation
-            from the payer. The fees applied by the payee will be acceptable to
-            the payer abiding by the limits set by optional
-            'perTransferFeeLimits' array.
+          description: Set to true if the quote response is accepted without confirmation from the payer. The fees applied by the payee will be acceptable to the payer abiding by the limits set by optional 'perTransferFeeLimits' array.
           type: object
           oneOf:
             - $ref: '#/components/schemas/autoAcceptQuote'
         skipPartyLookup:
-          description: >-
-            Set to true if supplying an FSPID for the payee party and no party
-            resolution is needed. This may be useful if a previous party
-            resolution has been performed.
+          description: Set to true if supplying an FSPID for the payee party and no party resolution is needed. This may be useful if a previous party resolution has been performed.
           type: boolean
         synchronous:
-          description: >-
-            Set to true if the bulkTransfer requests need be handled
-            synchronous. Otherwise the requests will be handled asynchronously,
-            meaning there will  be callbacks whenever the processing is done
+          description: Set to true if the bulkTransfer requests need be handled synchronous. Otherwise the requests will be handled asynchronously, meaning there will  be callbacks whenever the processing is done
           type: boolean
         bulkExpiration:
           $ref: '#/components/schemas/DateTime'
     PartyIdInfo:
       title: PartyIdInfo
       type: object
-      description: >-
-        Data model for the complex type PartyIdInfo. An ExtensionList element
-        has been added to this reqeust in version v1.1
+      description: Data model for the complex type PartyIdInfo. An ExtensionList element has been added to this reqeust in version v1.1
       properties:
         partyIdType:
           $ref: '#/components/schemas/PartyIdType'
@@ -1506,6 +1413,8 @@ components:
           $ref: '#/components/schemas/PartyComplexName'
         dateOfBirth:
           $ref: '#/components/schemas/DateOfBirth'
+        kycInformation:
+          $ref: '#/components/schemas/KYCInformation'
     Party:
       title: Party
       type: object
@@ -1519,6 +1428,13 @@ components:
           $ref: '#/components/schemas/PartyName'
         personalInfo:
           $ref: '#/components/schemas/PartyPersonalInfo'
+        supportedCurrencies:
+          type: array
+          description: Currencies in which the party can receive funds.
+          items:
+            $ref: '#/components/schemas/Currency'
+          minItems: 0
+          maxItems: 16
       required:
         - partyIdInfo
     bulkTransactionIndividualTransfer:
@@ -1528,9 +1444,7 @@ components:
       properties:
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         to:
           $ref: '#/components/schemas/Party'
         reference:
@@ -1567,9 +1481,7 @@ components:
       properties:
         bulkHomeTransactionID:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         bulkTransactionId:
           $ref: '#/components/schemas/CorrelationId'
         options:
@@ -1592,17 +1504,12 @@ components:
         - RESERVED
         - COMMITTED
         - ABORTED
-      description: >-
+      description: |-
         Below are the allowed values for the enumeration.
-
         - RECEIVED - Next ledger has received the transfer.
-
         - RESERVED - Next ledger has reserved the transfer.
-
         - COMMITTED - Next ledger has successfully performed the transfer.
-
-        - ABORTED - Next ledger has aborted the transfer due to a rejection or
-        failure to perform the transfer.
+        - ABORTED - Next ledger has aborted the transfer due to a rejection or failure to perform the transfer.
       example: RESERVED
     IlpFulfilment:
       title: IlpFulfilment
@@ -1639,9 +1546,7 @@ components:
           $ref: '#/components/schemas/CorrelationId'
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         bulkTransferState:
           $ref: '#/components/schemas/TransferState'
         completedTimestamp:
@@ -1684,17 +1589,13 @@ components:
             - true
             - false
     bulkTransactionContinuationAcceptParty:
-      description: >-
-        The object sent back as confirmation of payee parties when
-        autoAcceptParty is false.
+      description: The object sent back as confirmation of payee parties when autoAcceptParty is false.
       type: object
       required:
         - individualTransfers
       properties:
         individualTransfers:
-          description: >-
-            List of individual transfers in a bulk transfer with accept party
-            information.
+          description: List of individual transfers in a bulk transfer with accept party information.
           type: array
           minItems: 1
           items:
@@ -1712,9 +1613,7 @@ components:
             - true
             - false
     bulkTransactionContinuationAcceptQuote:
-      description: >-
-        The object sent back as confirmation of quotes when autoAcceptQuotes is
-        false.
+      description: The object sent back as confirmation of quotes when autoAcceptQuotes is false.
       type: object
       required:
         - individualTransfers
@@ -1729,15 +1628,11 @@ components:
               - $ref: '#/components/schemas/transferContinuationAcceptQuote'
     partyError:
       type: object
-      description: >-
-        This object represents a Mojaloop API error received at any time during
-        the party discovery process
+      description: This object represents a Mojaloop API error received at any time during the party discovery process
       properties:
         httpStatusCode:
           type: integer
-          description: >-
-            The HTTP status code returned to the caller. This is the same as the
-            actual HTTP status code returned with the response.
+          description: The HTTP status code returned to the caller. This is the same as the actual HTTP status code returned with the response.
         mojaloopError:
           $ref: '#/components/schemas/mojaloopError'
     bulkTransactionAcceptPartyErrorResponse:
@@ -1808,9 +1703,7 @@ components:
       properties:
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         bulkTransferId:
           $ref: '#/components/schemas/CorrelationId'
         bulkQuoteId:
@@ -1828,9 +1721,7 @@ components:
           $ref: '#/components/schemas/ExtensionList'
     individualTransferFulfilment:
       type: object
-      description: >-
-        A Mojaloop API transfer fulfilment for individual transfers in a bulk
-        transfer
+      description: A Mojaloop API transfer fulfilment for individual transfers in a bulk transfer
       properties:
         fulfilment:
           $ref: '#/components/schemas/IlpFulfilment'
@@ -1887,28 +1778,12 @@ components:
         - TRANSFER
         - PAYMENT
         - REFUND
-      description: >-
+      description: |-
         Below are the allowed values for the enumeration.
-
-        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a
-        normal scenario, electronic funds are transferred from a Business
-        account to a Consumer account, and physical cash is given from the
-        Consumer to the Business User.
-
-        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction.
-        In a normal scenario, electronic funds are transferred from a Consumer’s
-        account to a Business account, and physical cash is given from the
-        Business User to the Consumer.
-
-        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to
-        Consumer) transaction.
-
-        - PAYMENT - Usually used for performing a transaction from a Consumer to
-        a Merchant or Organization, but could also be for a B2B (Business to
-        Business) payment. The transaction could be online for a purchase in an
-        Internet store, in a physical store where both the Consumer and Business
-        User are present, a bill payment, a donation, and so on.
-
+        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a normal scenario, electronic funds are transferred from a Business account to a Consumer account, and physical cash is given from the Consumer to the Business User.
+        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction. In a normal scenario, electronic funds are transferred from a Consumer’s account to a Business account, and physical cash is given from the Business User to the Consumer.
+        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to Consumer) transaction.
+        - PAYMENT - Usually used for performing a transaction from a Consumer to a Merchant or Organization, but could also be for a B2B (Business to Business) payment. The transaction could be online for a purchase in an Internet store, in a physical store where both the Consumer and Business User are present, a bill payment, a donation, and so on.
         - REFUND - Used for performing a refund of transaction.
       example: DEPOSIT
     TransactionInitiator:
@@ -1917,17 +1792,10 @@ components:
       enum:
         - PAYER
         - PAYEE
-      description: >-
+      description: |-
         Below are the allowed values for the enumeration.
-
-        - PAYER - Sender of funds is initiating the transaction. The account to
-        send from is either owned by the Payer or is connected to the Payer in
-        some way.
-
-        - PAYEE - Recipient of the funds is initiating the transaction by
-        sending a transaction request. The Payer must approve the transaction,
-        either automatically by a pre-generated OTP or by pre-approval of the
-        Payee, or by manually approving in his or her own Device.
+        - PAYER - Sender of funds is initiating the transaction. The account to send from is either owned by the Payer or is connected to the Payer in some way.
+        - PAYEE - Recipient of the funds is initiating the transaction by sending a transaction request. The Payer must approve the transaction, either automatically by a pre-generated OTP or by pre-approval of the Payee, or by manually approving in his or her own Device.
       example: PAYEE
     RefundReason:
       title: RefundReason
@@ -1951,11 +1819,7 @@ components:
       title: BalanceOfPayments
       type: string
       pattern: ^[1-9]\d{2}$
-      description: >-
-        (BopCode) The API data type
-        [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String
-        of 3 characters, consisting of digits only. Negative numbers are not
-        allowed. A leading zero is not allowed.
+      description: (BopCode) The API data type [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String of 3 characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed.
       example: '123'
     TransactionType:
       title: TransactionType
@@ -1978,6 +1842,29 @@ components:
         - scenario
         - initiator
         - initiatorType
+    CurrencyConverter:
+      title: CurrencyConverter
+      type: string
+      enum:
+        - PAYER
+        - PAYEE
+      description: Below are the allowed values for the enumeration CurrencyConverter. - PAYER - Currency conversion should be performed by the payer. - PAYEE - Currency conversion should be performed by the payee.
+    FxRate:
+      title: FxRate
+      type: object
+      description: The FxRate object contains information about a currency conversion in the transfer. It can be used by parties to the transfer to exchange information with each other about the exchange rate for the transfer, to ensure that the best rate can be agreed on.
+      properties:
+        sourceAmount:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+            - description: The amount of the transfer in the source currency.
+        targetAmount:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+            - description: The amount of the transfer in the target currency.
+      required:
+        - sourceAmount
+        - targetAmount
     QuotesPostRequest:
       title: QuotesPostRequest
       type: object
@@ -2001,6 +1888,14 @@ components:
           $ref: '#/components/schemas/Money'
         transactionType:
           $ref: '#/components/schemas/TransactionType'
+        converter:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyConverter'
+            - description: An optional field which will allow the payer DFSP to specify which DFSP it wants to undertake currency conversion. This is useful incase of if the sender wants the recipient to receive a specified amount of the target currency, but the payer DFSP does not want to undertake the currency conversion. In this case, the amount of the transfer would be expressed in the target currency and the amountType would be set to RECEIVE.
+        currencyConversion:
+          allOf:
+            - $ref: '#/components/schemas/FxRate'
+            - description: Used by the debtor party if it wants to share information about the currency conversion it proposes to make; or if it is required by scheme rules to share this information. This object contains the amount of the transfer in the source and target currencies, but does not identify the FXP being used.
         geoCode:
           $ref: '#/components/schemas/GeoCode'
         note:
@@ -2047,12 +1942,10 @@ components:
                 payeeFspFee:
                   $ref: '#/components/schemas/Money'
                 payeeFspCommission:
-                  $ref: '#/components/schemas/Money'
+                  $ref: '#/components/schemas/fspMoney'
                 expiration:
                   type: string
-                  description: >-
-                    Date and time until when the quotation is valid and can be
-                    honored when used in the subsequent transaction.
+                  description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.
                   example: '2016-05-24T08:38:08.699-04:00'
                 geoCode:
                   $ref: '#/components/schemas/GeoCode'
@@ -2107,9 +2000,7 @@ components:
       properties:
         homeR2PTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         from:
           $ref: '#/components/schemas/transferParty'
         to:
@@ -2222,6 +2113,7 @@ components:
         - ERROR_OCCURRED
         - WAITING_FOR_PARTY_ACCEPTANCE
         - WAITING_FOR_QUOTE_ACCEPTANCE
+        - WAITING_FOR_CONVERSION_ACCEPTANCE
         - COMPLETED
     QuotesIDPutResponse:
       title: QuotesIDPutResponse
@@ -2235,7 +2127,7 @@ components:
         payeeFspFee:
           $ref: '#/components/schemas/Money'
         payeeFspCommission:
-          $ref: '#/components/schemas/Money'
+          $ref: '#/components/schemas/fspMoney'
         expiration:
           $ref: '#/components/schemas/DateTime'
         geoCode:
@@ -2251,6 +2143,111 @@ components:
         - expiration
         - ilpPacket
         - condition
+    FxMoney:
+      title: FxMoney
+      type: object
+      description: Data model for the complex type FxMoney; This is based on the type Money but allows the amount to be optional to support FX quotations.
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+      required:
+        - currency
+    FxCharge:
+      title: FxCharge
+      type: object
+      description: An FXP will be able to specify a charge which it proposes to levy on the currency conversion operation using a FxCharge object.
+      properties:
+        chargeType:
+          type: string
+          minLength: 1
+          maxLength: 32
+          description: A description of the charge which is being levied.
+        sourceAmount:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+            - description: The amount of the charge which is being levied, expressed in the source currency.
+        targetAmount:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+            - description: The amount of the charge which is being levied, expressed in the target currency.
+      required:
+        - chargeType
+    FxConversion:
+      title: FxConversion
+      type: object
+      description: A DFSP will be able to request a currency conversion, and an FX provider will be able to describe its involvement in a proposed transfer, using a FxConversion object.
+      properties:
+        conversionId:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+            - description: An end-to-end identifier for the conversion request.
+        determiningTransferId:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+            - description: The transaction ID of the transfer on whose success this currency conversion depends.
+        initiatingFsp:
+          allOf:
+            - $ref: '#/components/schemas/FspId'
+            - description: The id of the participant who is requesting a currency conversion.
+        counterPartyFsp:
+          allOf:
+            - $ref: '#/components/schemas/FspId'
+            - description: The ID of the FXP performing the conversion.
+        amountType:
+          allOf:
+            - $ref: '#/components/schemas/AmountType'
+            - description: This is the AmountType for the base transaction - If SEND - then any charges levied by the FXP as part of the transaction will be deducted by the FXP from the amount shown for the target party in the conversion. If RECEIVE - then any charges levied by the FXP as part of the transaction will be added by the FXP to the amount shown for the source party in the conversion.
+        sourceAmount:
+          allOf:
+            - $ref: '#/components/schemas/FxMoney'
+            - description: The amount to be converted, expressed in the source currency.
+        targetAmount:
+          allOf:
+            - $ref: '#/components/schemas/FxMoney'
+            - description: The converted amount, expressed in the target currency.
+        expiration:
+          allOf:
+            - $ref: '#/components/schemas/DateTime'
+            - description: The end of the period for which the currency conversion is required to remain valid.
+        charges:
+          type: array
+          description: One or more charges which the FXP intends to levy as part of the currency conversion, or which the payee DFSP intends to add to the amount transferred.
+          items:
+            $ref: '#/components/schemas/FxCharge'
+          minItems: 0
+          maxItems: 16
+        extensionList:
+          allOf:
+            - $ref: '#/components/schemas/ExtensionList'
+            - description: The extension list for the currency conversion request.
+      required:
+        - conversionId
+        - initiatingFsp
+        - counterPartyFsp
+        - amountType
+        - sourceAmount
+        - targetAmount
+        - expiration
+    FxQuotesPostOutboundResponse:
+      title: FxQuotesPostOutboundResponse
+      type: object
+      description: The object sent as a response for the POST /fxQuotes request. The terms under which the FXP will undertake the currency conversion proposed by the requester.
+      properties:
+        homeTransactionId:
+          description: Transaction ID for the FXP backend, used to reconcile transactions between the Switch and FXP backend systems.
+          type: string
+        condition:
+          allOf:
+            - $ref: '#/components/schemas/IlpCondition'
+            - description: The ILP condition for the conversion.
+        conversionTerms:
+          allOf:
+            - $ref: '#/components/schemas/FxConversion'
+            - description: The terms under which the FXP will undertake the currency conversion proposed by the requester.
+      required:
+        - conversionTerms
     TransfersIDPutResponse:
       title: TransfersIDPutResponse
       type: object
@@ -2281,9 +2278,7 @@ components:
           $ref: '#/components/schemas/CorrelationId'
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         from:
           $ref: '#/components/schemas/transferParty'
         to:
@@ -2306,13 +2301,25 @@ components:
           $ref: '#/components/schemas/CorrelationId'
         getPartiesResponse:
           type: object
-          required:
-            - body
           properties:
             body:
-              type: object
+              oneOf:
+                - type: object
+                  properties:
+                    party:
+                      $ref: '#/components/schemas/Party'
+                  required:
+                    - party
+                - type: object
+                  properties:
+                    errorInformation:
+                      $ref: '#/components/schemas/ErrorInformation'
+                  required:
+                    - errorInformation
             headers:
               type: object
+          required:
+            - body
         quoteResponse:
           type: object
           required:
@@ -2324,11 +2331,23 @@ components:
               type: object
         quoteResponseSource:
           type: string
-          description: >
-            FSPID of the entity that supplied the quote response. This may not
-            be the same as the FSPID of the entity which owns the end user
-            account in the case of a FOREX transfer. i.e. it may be a FOREX
-            gateway.
+          description: |
+            FSPID of the entity that supplied the quote response. This may not be the same as the FSPID of the entity which owns the end user account in the case of a FOREX transfer. i.e. it may be a FOREX gateway.
+        conversionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+        fxQuotesResponse:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              $ref: '#/components/schemas/FxQuotesPostOutboundResponse'
+            headers:
+              type: object
+        fxQuotesResponseSource:
+          type: string
+          description: |
+            FXPID of the entity that supplied the fxQuotes response.
         fulfil:
           type: object
           required:
@@ -2341,10 +2360,7 @@ components:
         lastError:
           $ref: '#/components/schemas/transferError'
         skipPartyLookup:
-          description: >-
-            Set to true if supplying an FSPID for the payee party and no party
-            resolution is needed. This may be useful is a previous party
-            resolution has been performed.
+          description: Set to true if supplying an FSPID for the payee party and no party resolution is needed. This may be useful is a previous party resolution has been performed.
           type: boolean
     errorTransferResponse:
       allOf:
@@ -2371,9 +2387,7 @@ components:
       properties:
         homeR2PTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         transactionRequestId:
           $ref: '#/components/schemas/CorrelationId'
         from:
@@ -2404,10 +2418,7 @@ components:
         - title: OtpValue
           type: string
           pattern: ^\d{3,10}$
-          description: >-
-            The API data type OtpValue is a JSON String of 3 to 10 characters,
-            consisting of digits only. Negative numbers are not allowed. One or
-            more leading zeros are allowed.
+          description: The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. Negative numbers are not allowed. One or more leading zeros are allowed.
         - title: QRCODE
           type: string
           minLength: 1
@@ -2415,33 +2426,26 @@ components:
           description: QR code used as a One Time Password.
         - title: U2FPinValue
           type: object
-          description: >
-            U2F challenge-response, where payer FSP verifies if the response
-            provided by end-user device matches the previously registered key.
+          description: |
+            U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
           properties:
             pinValue:
               type: string
               pattern: ^\S{1,64}$
               minLength: 1
               maxLength: 64
-              description: >
-                U2F challenge-response, where payer FSP verifies if the response
-                provided by end-user device matches the previously registered
-                key.
+              description: |
+                U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
             counter:
               title: Integer
               type: string
               pattern: ^[1-9]\d*$
-              description: >-
-                Sequential counter used for cloning detection. Present only for
-                U2F authentication.
+              description: Sequential counter used for cloning detection. Present only for U2F authentication.
           required:
             - pinValue
             - counter
       pattern: ^\d{3,10}$|^\S{1,64}$
-      description: >-
-        Contains the authentication value. The format depends on the
-        authentication type used in the AuthenticationInfo complex type.
+      description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
     AuthenticationInfo:
       title: AuthenticationInfo
       type: object
@@ -2493,9 +2497,7 @@ components:
           $ref: '#/components/schemas/CorrelationId'
         homeR2PTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         transactionRequestId:
           $ref: '#/components/schemas/CorrelationId'
         from:
@@ -2527,11 +2529,8 @@ components:
               type: object
         quoteResponseSource:
           type: string
-          description: >
-            FSPID of the entity that supplied the quote response. This may not
-            be the same as the FSPID of the entity which owns the end user
-            account in the case of a FOREX transfer. i.e. it may be a FOREX
-            gateway.
+          description: |
+            FSPID of the entity that supplied the quote response. This may not be the same as the FSPID of the entity which owns the end user account in the case of a FOREX transfer. i.e. it may be a FOREX gateway.
         authorizationResponse:
           type: object
           required:
@@ -2637,9 +2636,7 @@ components:
       properties:
         homeTransactionId:
           type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
+          description: Transaction ID from the DFSP backend, used to reconcile transactions between the Switch and DFSP backend systems.
         from:
           $ref: '#/components/schemas/transferParty'
         to:
@@ -2661,10 +2658,7 @@ components:
         transferRequestExtensions:
           $ref: '#/components/schemas/extensionListEmptiable'
         skipPartyLookup:
-          description: >-
-            Set to true if supplying an FSPID for the payee party and no party
-            resolution is needed. This may be useful is a previous party
-            resolution has been performed.
+          description: Set to true if supplying an FSPID for the payee party and no party resolution is needed. This may be useful is a previous party resolution has been performed.
           type: boolean
     transferStatusResponse:
       type: object
@@ -2686,7 +2680,148 @@ components:
               $ref: '#/components/schemas/TransfersIDPutResponse'
             headers:
               type: object
+    transferContinuationAcceptConversion:
+      type: object
+      required:
+        - acceptConversion
+      properties:
+        acceptConversion:
+          type: boolean
+          enum:
+            - true
+            - false
+    ServicesFXPPutResponse:
+      title: ServicesFXPPutResponse
+      type: object
+      description: The object sent in the PUT /services/FXP callback.
+      properties:
+        providers:
+          type: array
+          description: The FSP Id(s) of the participant(s) who offer currency conversion services.
+          items:
+            $ref: '#/components/schemas/FspId'
+          minItems: 0
+          maxItems: 16
+      required:
+        - providers
+    FxQuotesPostOutboundRequest:
+      title: FxQuotesPostOutboundRequest
+      type: object
+      description: The object sent in the POST /fxQuotes request.
+      properties:
+        homeTransactionId:
+          description: Transaction ID for the backend, used to reconcile transactions between the Switch and backend systems.
+          type: string
+        conversionRequestId:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+            - description: An end-to-end identifier for the conversion quotation request.
+        conversionTerms:
+          allOf:
+            - $ref: '#/components/schemas/FxConversion'
+            - description: The terms of the currency conversion for which a quotation is sought.
+      required:
+        - conversionRequestId
+        - conversionTerms
+    commitRequestId:
+      allOf:
+        - $ref: '#/components/schemas/CorrelationId'
+        - description: An end-to-end identifier for the confirmation request.
+    determiningTransferId:
+      allOf:
+        - $ref: '#/components/schemas/CorrelationId'
+        - description: The transaction ID of the transfer to which this currency conversion relates, if the conversion is part of a transfer. If the conversion is a bulk currency purchase, this field should be omitted.
+    initiatingFsp:
+      allOf:
+        - $ref: '#/components/schemas/FspId'
+        - description: Identifier for the FSP who is requesting a currency conversion.
+    counterPartyFsp:
+      allOf:
+        - $ref: '#/components/schemas/FspId'
+        - description: Identifier for the FXP who is performing the currency conversion.
+    sourceAmount:
+      allOf:
+        - $ref: '#/components/schemas/Money'
+        - description: The amount being offered for conversion by the requesting FSP.
+    targetAmount:
+      allOf:
+        - $ref: '#/components/schemas/Money'
+        - description: The amount which the FXP is to credit to the requesting FSP in the target currency.
+    condition:
+      allOf:
+        - $ref: '#/components/schemas/IlpCondition'
+        - description: ILP condition received by the requesting FSP when the quote was approved.
+    FxTransfersPostOutboundRequest:
+      title: FxTransfersPostOutboundRequest
+      type: object
+      description: The object sent in the POST /fxTransfers request.
+      properties:
+        homeTransactionId:
+          description: Transaction ID for the backend, used to reconcile transactions between the Switch and backend systems.
+          type: string
+        commitRequestId:
+          $ref: '#/components/schemas/commitRequestId'
+        determiningTransferId:
+          $ref: '#/components/schemas/determiningTransferId'
+        initiatingFsp:
+          $ref: '#/components/schemas/initiatingFsp'
+        counterPartyFsp:
+          $ref: '#/components/schemas/counterPartyFsp'
+        sourceAmount:
+          $ref: '#/components/schemas/sourceAmount'
+        targetAmount:
+          $ref: '#/components/schemas/targetAmount'
+        condition:
+          $ref: '#/components/schemas/condition'
+      required:
+        - commitRequestId
+        - initiatingFsp
+        - counterPartyFsp
+        - sourceAmount
+        - targetAmount
+    fulfilment:
+      allOf:
+        - $ref: '#/components/schemas/IlpFulfilment'
+        - description: The fulfilment of the condition specified for the currency conversion. Mandatory if the conversion has been executed successfully.
+    completedTimestamp:
+      allOf:
+        - $ref: '#/components/schemas/DateTime'
+        - description: Time and date when the conversion was executed.
+    conversionState:
+      allOf:
+        - $ref: '#/components/schemas/TransferState'
+        - description: The current status of the conversion request.
+    FxTransfersPostOutboundResponse:
+      title: FxTransfersPostOutboundResponse
+      type: object
+      description: The object sent as a response for the POST /fxTransfers request.
+      properties:
+        homeTransactionId:
+          description: Transaction ID for the backend, used to reconcile transactions between the Switch and backend systems.
+          type: string
+        fulfilment:
+          $ref: '#/components/schemas/fulfilment'
+        completedTimestamp:
+          $ref: '#/components/schemas/completedTimestamp'
+        conversionState:
+          $ref: '#/components/schemas/conversionState'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - conversionState
   responses:
+    '400':
+      description: Malformed or missing required headers or parameters.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorResponse'
+    '500':
+      description: An error occurred processing the request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorResponse'
     accountsCreationCompleted:
       description: Accounts creation completed
       content:
@@ -2838,6 +2973,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/errorTransferResponse'
+    servicesFXPSucess:
+      description: The response contains participants in a scheme who offer currency conversion services. If no participants offer these services, the return object will be blank.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ServicesFXPPutResponse'
   parameters:
     bulkQuoteId:
       name: bulkQuoteId
@@ -2845,27 +2986,21 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the bulk transfer to continue as returned in the response
-        to a `POST /bulkTransfers` request.
+      description: Identifier of the bulk transfer to continue as returned in the response to a `POST /bulkTransfers` request.
     bulkTransactionId:
       name: bulkTransactionId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the bulk transaction to continue as returned in the
-        response to a `POST /bulkTransaction` request.
+      description: Identifier of the bulk transaction to continue as returned in the response to a `POST /bulkTransaction` request.
     bulkTransferId:
       name: bulkTransferId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the bulk transfer to continue as returned in the response
-        to a `POST /bulkTransfers` request.
+      description: Identifier of the bulk transfer to continue as returned in the response to a `POST /bulkTransfers` request.
     Type:
       name: Type
       in: path
@@ -2886,24 +3021,32 @@ components:
       required: true
       schema:
         type: string
-      description: >-
-        A sub-identifier of the party identifier, or a sub-type of the party
-        identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+      description: A sub-identifier of the party identifier, or a sub-type of the party identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
     transactionRequestId:
       name: transactionRequestId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the merchant request to pay to continue as returned in the
-        response to a `POST /requestToPay` request.
+      description: Identifier of the merchant request to pay to continue as returned in the response to a `POST /requestToPay` request.
     transferId:
       name: transferId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the transfer to continue as returned in the response to a
-        `POST /transfers` request.
+      description: Identifier of the transfer to continue as returned in the response to a `POST /transfers` request.
+    SourceCurrency:
+      name: SourceCurrency
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ISO 4217 currency code for the source currency.
+    TargetCurrency:
+      name: TargetCurrency
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ISO 4217 currency code for the target currency.

--- a/zicb-zm-core-connector/src/api-spec/core-connector-api-spec-dfsp.yml
+++ b/zicb-zm-core-connector/src/api-spec/core-connector-api-spec-dfsp.yml
@@ -231,12 +231,12 @@ components:
         payeeIdType:
           type: string
           example: "MSISDN"
-        sendAmount:
-          type: string
-          example: "150.00"
         sendCurrency:
           type: string
           example: "UGX"
+        receiveAmount:
+          type: string
+          example: "150.00"
         receiveCurrency:
           type: string
           example: "KES"
@@ -303,28 +303,28 @@ components:
             fspId:
               type: string
               example: "airtelzambia"
-            firstName:
+            name:
               type: string
-              example: "Niza"
-            lastName:
-              type: string
-              example: "Tembo"
-            dateOfBirth:
-              type: string
-              example: "1997/09/04"
+              example: "Chimweso"
 
+        sendAmount:
+          type: string
+          example: "140.00"
+        sendCurrency:
+          type: string
+          example: "ZMW"
         receiveAmount:
           type: string
           example: "140.00"
         receiveCurrency:
           type: string
-          example: "EUR"
-        fees:
+          example: "MWK"
+        targetFees:
           type: string
           example: "10.00"
-        feeCurrency:
+        sourceFees:
           type: string
-          example: "USD"
+          example: "10.00"
         transactionId:
           type: string
           example: "42fdb186-2a36-46f1-9be9-8989a9e0aeb4"
@@ -343,28 +343,28 @@ components:
             fspId:
               type: string
               example: "airtelzambia"
-            firstName:
+            name:
               type: string
-              example: "Niza"
-            lastName:
-              type: string
-              example: "Tembo"
-            dateOfBirth:
-              type: string
-              example: "1997/09/04"
+              example: "Chimweso"
 
+        sendAmount:
+          type: string
+          example: "140.00"
+        sendCurrency:
+          type: string
+          example: "ZMW"
         receiveAmount:
           type: string
           example: "140.00"
         receiveCurrency:
           type: string
-          example: "EUR"
-        fees:
+          example: "MWK"
+        targetFees:
           type: string
           example: "10.00"
-        feeCurrency:
+        sourceFees:
           type: string
-          example: "USD"
+          example: "10.00"
         transactionId:
           type: string
           example: "01JKB0F2WV7YVSA6CXGP977XT9"
@@ -444,9 +444,9 @@ components:
       properties:
         acceptQuote:
           type: boolean
-        accountNo:
+        msisdn:
           type: string
-          example: "1019000002881"
+          example: "777503758"
         amount:
           type: string
           example: "500"

--- a/zicb-zm-core-connector/src/domain/CBSClient/types.ts
+++ b/zicb-zm-core-connector/src/domain/CBSClient/types.ts
@@ -67,7 +67,26 @@ export type TZicbSendMoneyRequest = {
     };
 }
 
-export type TZicbMerchantPaymentRequest = TZicbSendMoneyRequest;
+export type TZicbMerchantPaymentRequest = {
+    "homeTransactionId": string;
+    "payeeId": string;
+    "payeeIdType": components["schemas"]["PartyIdType"];
+    "sendCurrency": components['schemas']['Currency'];
+    "receiveAmount": string;
+    "receiveCurrency": components['schemas']['Currency'];
+    "transactionDescription": string;
+    "transactionType": components['schemas']['transferTransactionType'];
+    "payer": {
+        "name": string;
+        "payerId": string;
+        "DateAndPlaceOfBirth": {
+            "BirthDt": string;
+            "PrvcOfBirth": string;
+            "CityOfBirth": string;
+            "CtryOfBirth": string;
+        }
+    }
+}
 
 // Response sent back to ZICB
 
@@ -76,17 +95,17 @@ export type TZicbSendMoneyResponse = {
         "idType": string;
         "idValue": string;
         "fspId": string;
-        "firstName": string;
-        "lastName": string;
-        "dateOfBirth": string;
-    },
-    "receiveAmount": string;
-    "receiveCurrency": string;
-    "fees": string;
-    "feeCurrency": string;
+        "name": string;
+    };
+    "sendAmount": string,
+    "sendCurrency": string,
+    "receiveAmount": string,
+    "receiveCurrency": string,
+    "targetFees": string,
+    "sourceFees": string,
     "transactionId": string;
+    "homeTransactionId": string;
 }
-
 export type TZicbMerchantPaymentResponse = TZicbSendMoneyResponse;
 
 export type TZicbUpdateSendMoneyRequest = {

--- a/zicb-zm-core-connector/src/domain/SDKClient/types.ts
+++ b/zicb-zm-core-connector/src/domain/SDKClient/types.ts
@@ -61,7 +61,17 @@ export type TSDKOutboundTransferResponse = {
     currentState?: components["schemas"]["transferStatus"];
     quoteId?: components["schemas"]["CorrelationId"];
     getPartiesResponse?: {
-        body: Record<string, never>;
+        body: {
+            party: {
+                partyIdInfo: {
+                    partyIdType: string,
+                    partyIdentifier: string,
+                    fspId: string
+                },
+                name: string,
+                supportedCurrencies: string[],
+            }
+        };
         headers?: Record<string, never>;
     };
     quoteResponse?: {
@@ -93,7 +103,7 @@ export type TSDKTransferContinuationRequest =
     | components['schemas']['transferContinuationAcceptConversion'];
 
 
-export type TtransferContinuationResponse = SDKSchemeAdapter.V2_0_0.Outbound.Types.transferResponse;
+export type TtransferContinuationResponse = TSDKOutboundTransferResponse;
 
 export type TSDKClientDeps = {
     logger: ILogger;

--- a/zicb-zm-core-connector/src/domain/coreConnectorAgg.ts
+++ b/zicb-zm-core-connector/src/domain/coreConnectorAgg.ts
@@ -32,6 +32,7 @@ import {
     IZicbClient,
     TZicbConfig,
     TZicbSendMoneyResponse,
+    TZicbMerchantPaymentRequest
 
 } from './CBSClient';
 import {
@@ -425,13 +426,16 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
     // Payer
     // Send Money -- (5)
 
-    async sendMoney(transfer: TZicbSendMoneyRequest, amountType: "SEND" | "RECEIVE"): Promise<TZicbSendMoneyResponse> {
+    async sendMoney(transfer: TZicbSendMoneyRequest | TZicbMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): Promise<TZicbSendMoneyResponse> {
         this.logger.info(`Received send money request for payer with ID ${transfer.payer.payerId}`);
-        const res = await this.sdkClient.initiateTransfer(await this.getTSDKOutboundTransferRequest(transfer, amountType));
+
+        const transferRequest: TSDKOutboundTransferRequest = await this.getTSDKOutboundTransferRequest(transfer, amountType)
+        const res = await this.sdkClient.initiateTransfer(transferRequest);
+        
         if (res.data.currentState === "WAITING_FOR_CONVERSION_ACCEPTANCE") {
-            return this.handleSendTransferRes(res.data);
+            return this.handleSendTransferRes(res.data, transfer.homeTransactionId);
         } else if (res.data.currentState === "WAITING_FOR_QUOTE_ACCEPTANCE") {
-            return this.handleReceiveTransferRes(res.data);
+            return this.handleReceiveTransferRes(res.data, transfer.homeTransactionId);
         } else {
             throw SDKClientError.returnedCurrentStateUnsupported(`Returned currentStateUnsupported. ${res.data.currentState}`, { httpCode: 500, mlCode: "2000" });
         }
@@ -439,7 +443,7 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
 
     // Handle Send Transfer -- (5.1)
 
-    private async handleSendTransferRes(res: TSDKOutboundTransferResponse): Promise<TZicbSendMoneyResponse> {
+    private async handleSendTransferRes(res: TSDKOutboundTransferResponse, homeTransactionId: string): Promise<TZicbSendMoneyResponse> {
         /*
             check fxQuote
             respond to conversion terms
@@ -461,16 +465,18 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
         acceptRes = await this.sdkClient.updateTransfer({
             "acceptConversion": true
         }, res.transferId);
+
+        
         const validateQuoteRes = this.validateReturnedQuote(acceptRes.data);
         if (!validateQuoteRes.result) {
             throw ValidationError.invalidReturnedQuoteError(validateQuoteRes.message.toString());
         }
-        return this.getTZicbSendMoneyResponse(acceptRes.data);
+        return this.getTZicbSendMoneyResponse(acceptRes.data, homeTransactionId);
     }
 
     // Handle Recieve Transfer  -- (5.2)
 
-    private async handleReceiveTransferRes(res: TSDKOutboundTransferResponse): Promise<TZicbSendMoneyResponse> {
+    private async handleReceiveTransferRes(res: TSDKOutboundTransferResponse,  homeTransactionId: string): Promise<TZicbSendMoneyResponse> {
         /*
             check returned normalQuote
             respond to quote 
@@ -496,7 +502,7 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
         if (!validateFxRes.result) {
             throw ValidationError.invalidConversionQuoteError(validateFxRes.message.toString(), "4000", 500);
         }
-        return this.getTZicbSendMoneyResponse(acceptRes.data);
+        return this.getTZicbSendMoneyResponse(acceptRes.data, homeTransactionId);
     }
 
     // Validate Conversion Terms (5.2.1)
@@ -541,46 +547,46 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
 
     // Validate Returned  Quote (5.2.2)
 
-    private validateReturnedQuote(outboundTransferRes: TSDKOutboundTransferResponse): TValidationResponse {
-        this.logger.info(`Validating Retunred Quote with transfer response amount${outboundTransferRes.amount}`);
+    private validateReturnedQuote(transferResponse: TSDKOutboundTransferResponse): TValidationResponse {
+        this.logger.info(`Validating Retunred Quote with transfer response amount${transferResponse.amount}`);
         let result = true;
         const message: string[] = [];
-        if (outboundTransferRes.amountType === "SEND") {
-            const validateFxRes = this.validateConversionTerms(outboundTransferRes);
+        if (transferResponse.amountType === "SEND") {
+            const validateFxRes = this.validateConversionTerms(transferResponse);
             if (!validateFxRes.result) {
                 result = false;
                 message.push(...validateFxRes.message);
             }
         }
-        const quoteResponseBody = outboundTransferRes.quoteResponse?.body;
-        const fxQuoteResponseBody = outboundTransferRes.fxQuoteResponse?.body;
+        const quoteResponseBody = transferResponse.quoteResponse?.body;
+        const fxQuoteResponseBody = transferResponse.fxQuoteResponse?.body;
         if (!quoteResponseBody) {
             throw SDKClientError.noQuoteReturnedError();
         }
-        if (outboundTransferRes.amountType === "SEND") {
-            const quoteRequestAmount: string = outboundTransferRes.fxQuoteResponse?.body?.conversionTerms?.targetAmount?.amount ? outboundTransferRes.fxQuoteResponse?.body?.conversionTerms?.targetAmount?.amount : outboundTransferRes.amount;
+        if (transferResponse.amountType === "SEND") {
+            const quoteRequestAmount: string = transferResponse.fxQuoteResponse?.body?.conversionTerms?.targetAmount?.amount ? transferResponse.fxQuoteResponse?.body?.conversionTerms?.targetAmount?.amount : transferResponse.amount;
             if (!(parseFloat(quoteRequestAmount) === parseFloat(quoteResponseBody.transferAmount.amount) - parseFloat(quoteResponseBody.payeeFspCommission?.amount || "0"))) {
                 result = false;
-                message.push(`outboundTransferRes.amount ${outboundTransferRes.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount} minus quoteResponseBody.payeeFspCommission?.amount ${quoteResponseBody.payeeFspCommission?.amount}`);
+                message.push(`transferResponse.amount ${transferResponse.amount} or transferResponse.fxQuoteResponse?.body?.conversionTerms?.targetAmount?.amount ${transferResponse.fxQuoteResponse?.body?.conversionTerms?.targetAmount?.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount} minus quoteResponseBody.payeeFspCommission?.amount ${quoteResponseBody.payeeFspCommission?.amount}`);
             }
             if (!quoteResponseBody.payeeReceiveAmount) {
                 throw SDKClientError.genericQuoteValidationError("Payee Receive Amount not defined", { httpCode: 500, mlCode: "4000" });
             }
             if (!(parseFloat(quoteResponseBody.payeeReceiveAmount.amount) === parseFloat(quoteResponseBody.transferAmount.amount) - parseFloat(quoteResponseBody.payeeFspCommission?.amount || '0'))) {
                 result = false;
-                message.push(`quoteResponseBody.payeeReceiveAmount.amount ${quoteResponseBody.payeeReceiveAmount.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount} minus quoteResponseBody.payeeFspCommission?.amount ${quoteResponseBody.payeeFspCommission?.amount}`);
+                message.push(`quoteResponseBody.payeeReceiveAmount.amount ${quoteResponseBody.payeeReceiveAmount.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount} minus quoteResponseBody.payeeFspCommission?.amount || '0' ${quoteResponseBody.payeeFspCommission?.amount || '0'}  `);
             }
             if (!(fxQuoteResponseBody?.conversionTerms.targetAmount.amount === quoteResponseBody.transferAmount.amount)) {
                 result = false;
                 message.push(`fxQuoteResponseBody?.conversionTerms.targetAmount.amount ${fxQuoteResponseBody?.conversionTerms.targetAmount.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount}`);
             }
-        } else if (outboundTransferRes.amountType === "RECEIVE") {
-            if (!outboundTransferRes.quoteResponse) {
+        } else if (transferResponse.amountType === "RECEIVE") {
+            if (!transferResponse.quoteResponse) {
                 throw SDKClientError.noQuoteReturnedError();
             }
-            if (!(parseFloat(outboundTransferRes.amount) === parseFloat(quoteResponseBody.transferAmount.amount) - parseFloat(quoteResponseBody.payeeFspCommission?.amount || "0") + parseFloat(quoteResponseBody.payeeFspFee?.amount || "0"))) {
+            if (!(parseFloat(transferResponse.amount) === parseFloat(quoteResponseBody.transferAmount.amount) - parseFloat(quoteResponseBody.payeeFspCommission?.amount || "0") + parseFloat(quoteResponseBody.payeeFspFee?.amount || "0"))) {
                 result = false;
-                message.push(`outboundTransferRes.amount ${outboundTransferRes.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount} minus quoteResponseBody.payeeFspCommission?.amount ${quoteResponseBody.payeeFspCommission?.amount} plus quoteResponseBody.payeeFspFee?.amount ${quoteResponseBody.payeeFspFee?.amount}`);
+                message.push(`transferResponse.amount ${transferResponse.amount} did not equal quoteResponseBody.transferAmount.amount ${quoteResponseBody.transferAmount.amount} minus quoteResponseBody.payeeFspCommission?.amount || "0" ${quoteResponseBody.payeeFspCommission?.amount || "0"} plus quoteResponseBody.payeeFspFee?.amount || "0" ${quoteResponseBody.payeeFspFee?.amount || "0"}  `);
             }
 
             if (!(quoteResponseBody.payeeReceiveAmount?.amount === quoteResponseBody.transferAmount.amount)) {
@@ -599,26 +605,41 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
         return { result, message };
     }
 
-    private getTZicbSendMoneyResponse(transfer: TSDKOutboundTransferResponse): TZicbSendMoneyResponse {
+    private getTZicbSendMoneyResponse(transfer: TSDKOutboundTransferResponse, homeTransactionId: string): TZicbSendMoneyResponse {
         this.logger.info(`Getting response for transfer with Id ${transfer.transferId}`);
+
         return {
             "payeeDetails": {
                 "idType": transfer.to.idType,
                 "idValue": transfer.to.idValue,
                 "fspId": transfer.to.fspId !== undefined ? transfer.to.fspId : "No FSP ID Returned",
-                "firstName": transfer.to.firstName !== undefined ? transfer.to.firstName : "No First Name Returned",
-                "lastName": transfer.to.lastName !== undefined ? transfer.to.lastName : "No Last Name Returned",
-                "dateOfBirth": transfer.to.dateOfBirth !== undefined ? transfer.to.dateOfBirth : "No Date of Birth Returned",
+                "name": transfer.getPartiesResponse?.body.party.name !== undefined ? transfer.getPartiesResponse?.body.party.name : ""
             },
+            "sendAmount": transfer.fxQuoteResponse?.body.conversionTerms.sourceAmount.amount !== undefined ? transfer.fxQuoteResponse.body.conversionTerms.sourceAmount.amount : "No send amount ",
+            "sendCurrency": transfer.fxQuoteResponse?.body.conversionTerms.sourceAmount.currency !== undefined ? transfer.fxQuoteResponse.body.conversionTerms.sourceAmount.currency : "No send currency ",
             "receiveAmount": transfer.quoteResponse?.body.payeeReceiveAmount?.amount !== undefined ? transfer.quoteResponse.body.payeeReceiveAmount.amount : "No payee receive amount",
             "receiveCurrency": transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency !== undefined ? transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency : "No Currency returned from Mojaloop Connector",
-            "fees": transfer.quoteResponse?.body.payeeFspFee?.amount !== undefined ? transfer.quoteResponse?.body.payeeFspFee?.amount : "No fee amount returned from Mojaloop Connector",
-            "feeCurrency": transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency !== undefined ? transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency : "No Fee currency retrned from Mojaloop Connector",
+            "targetFees": this.getQuoteCharges(transfer,),
+            "sourceFees": this.getFxQuoteResponseCharges(transfer),
             "transactionId": transfer.transferId !== undefined ? transfer.transferId : "No transferId returned",
+            "homeTransactionId": homeTransactionId
         };
     }
 
-    private async getTSDKOutboundTransferRequest(transfer: TZicbSendMoneyRequest, amountType: "SEND" | "RECEIVE"): Promise<TSDKOutboundTransferRequest> {
+    private getQuoteCharges(transferRes: TSDKOutboundTransferResponse): string {
+        return parseFloat(transferRes.quoteResponse?.body.payeeFspFee?.amount ?? "0").toString();
+    }
+
+    private getFxQuoteResponseCharges(data: TSDKOutboundTransferResponse): string {
+        if (data.fxQuoteResponse && data.fxQuoteResponse.body.conversionTerms.charges) {
+            return data.fxQuoteResponse.body.conversionTerms.charges.reduce((total, charge) => {
+                return total + parseFloat(charge.sourceAmount !== undefined ? charge.sourceAmount.amount : "0");
+            }, 0).toString();
+        }
+        return "0";
+    }
+
+    private async getTSDKOutboundTransferRequest(transfer: TZicbSendMoneyRequest | TZicbMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): Promise<TSDKOutboundTransferRequest> {
 
         const verifyCustomerByAccountNumberRequestBody = this.getVerifyByCustomerAccountNumberRequestBody(transfer.payer.payerId);
         const res = await this.zicbClient.verifyCustomerByAccountNumber(verifyCustomerByAccountNumberRequestBody);
@@ -635,7 +656,6 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
                 "firstName": this.extractNames(res.response.accountList[0].accDesc).firstName,
                 "middleName": this.extractNames(res.response.accountList[0].accDesc).firstName,
                 "lastName": this.extractNames(res.response.accountList[0].accDesc).lastName,
-                "extensionList": this.getOutboundTransferExtensionList(transfer),
                 "supportedCurrencies": [this.zicbConfig.X_CURRENCY]
             },
             'to': {
@@ -643,30 +663,40 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
                 'idValue': transfer.payeeId
             },
             'amountType': amountType,
-            'currency': transfer.sendCurrency,
-            'amount': transfer.sendAmount,
+            'currency':  amountType === "SEND" ? transfer.sendCurrency : transfer.receiveCurrency,
+            'amount': "sendAmount" in transfer ? transfer.sendAmount : transfer.receiveAmount,
             'transactionType': transfer.transactionType,
+            'quoteRequestExtensions': this.getOutboundTransferExtensionList(transfer, amountType),
+            'transferRequestExtensions': this.getOutboundTransferExtensionList(transfer, amountType)
         };
     }
 
-    private getOutboundTransferExtensionList(sendMoneyRequestPayload: TZicbSendMoneyRequest): TPayerExtensionListEntry[] | undefined {
+    private getOutboundTransferExtensionList(sendMoneyRequestPayload: TZicbSendMoneyRequest | TZicbMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): TPayerExtensionListEntry[] | undefined {
         if (sendMoneyRequestPayload.payer.DateAndPlaceOfBirth) {
             return [
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.BirthDt",
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.BirthDt",
                     "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.BirthDt
                 },
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.PrvcOfBirth",
-                    "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth ? "Not defined" : sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.PrvcOfBirth",
+                    "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth ? sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth : "Not defined"
                 },
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.CityOfBirth",
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.CityOfBirth",
                     "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.CityOfBirth
                 },
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.CtryOfBirth",
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.CtryOfBirth",
                     "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.CtryOfBirth
+                },
+                {
+                    "key": "CdtTrfTxInf.Dbtr.Nm",
+                    "value": sendMoneyRequestPayload.payer.name
+                },
+                {
+                    "key": "CdtTrfTxInf.Purp.Cd",
+                    "value": amountType === "SEND" ? "MP2P" : "IPAY"
                 }
             ];
         }

--- a/zicb-zm-core-connector/test/unit/domain/coreConnectorAgg.test.ts
+++ b/zicb-zm-core-connector/test/unit/domain/coreConnectorAgg.test.ts
@@ -554,11 +554,12 @@ describe('CoreConnectorAggregate Tests -->', () => {
 
             // Get the Reguest being Used to call
             const transferRequest = initiateTransferSpy.mock.calls[0][0];
+            logger.info("Transfer Request", transferRequest);
 
             // Check the Extension List is not 0
-            expect(transferRequest.from.extensionList).not.toHaveLength(0);
-            if (transferRequest.from.extensionList) {
-                expect(transferRequest.from.extensionList[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.BirthDt");
+            expect(transferRequest.quoteRequestExtensions).not.toHaveLength(0);
+            if (transferRequest.quoteRequestExtensions) {
+                expect(transferRequest.quoteRequestExtensions[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.BirthDt");
             }
             logger.info("Trasnfer REquest  being sent to Initiate Transfer", transferRequest);
 
@@ -750,9 +751,9 @@ describe('CoreConnectorAggregate Tests -->', () => {
             const transferRequest = initiateTransferSpy.mock.calls[0][0];
 
             // Check the Extension List is not 0
-            expect(transferRequest.from.extensionList).not.toHaveLength(0);
-            if (transferRequest.from.extensionList) {
-                expect(transferRequest.from.extensionList[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.BirthDt");
+            expect(transferRequest.quoteRequestExtensions).not.toHaveLength(0);
+            if (transferRequest.quoteRequestExtensions) {
+                expect(transferRequest.quoteRequestExtensions[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.BirthDt");
             }
             logger.info("Transfer Request  being sent to Initiate Transfer", transferRequest);
         });


### PR DESCRIPTION
the send-money response was edited in the api spec. Also the merchant-payment request body was changed to spedicify the recieveAmount and not sendAmount. The getTSDKOutboundTransferRequest  DTO was refactored to dynamically specify the sendAmount or receiveAmount depending on whether the request is a merchant payment or send money. The ISO20022 paths were fixed in the getOutboundTransferExtensionList  DTO to include ID and name.  The unit tests were refactored to conform to the updated request bodies.