### PR TITLE
 Feat: Application of final fixes and updates to the Airtel Core Connector

### DIFF
--- a/airtel-zm-core-connector/src/api-spec/core-connector-api-spec-dfsp.yml
+++ b/airtel-zm-core-connector/src/api-spec/core-connector-api-spec-dfsp.yml
@@ -137,12 +137,12 @@ paths:
           description: >-
             Transfer Timeout.
 
-  /merchant-payment/{id}:
+  /merchant-payment/{transferId}:
     put:
       summary: Confirm send money
       operationId: updateInitiatedMerchantPayment
       parameters:
-        - name: id
+        - name: transferId
           in: path
           required: true
           description: The ID of the transaction
@@ -183,30 +183,42 @@ components:
     callbackPayload:
       type: object
       properties:
-        transaction:
+        financialTransactionId:
+          type: string
+          example: BBZMiscxy
+          description: Unique identifier for the transaction.
+        externalId:
+          type: string
+          example: "EXT123456789"
+          description: External reference ID for the transaction.
+        amount:
+          type: string
+          example: "5000"
+          description: Transaction amount.
+        currency:
+          type: string
+          example: "UGX"
+          description: Currency of the transaction.
+        payee:
           type: object
           properties:
-            id:
+            partyIdType:
               type: string
-              example: BBZMiscxy
-              description: Unique identifier for the transaction.
-            message:
+              example: "MSISDN"
+              description: Type of identifier for the payee.
+            partyId:
               type: string
-              example: Paid UGX 5,000 to TECHNOLOGIES LIMITED Charge UGX 140, Trans ID MP210603.1234.L06941.
-              description: Transaction message detailing payment, charges, and transaction ID.
-            status_code:
-              type: string
-              example: TS
-              description: Status code of the transaction.
-            airtel_money_id:
-              type: string
-              example: MP210603.1234.L06941
-              description: Airtel money transaction ID.
-          required:
-            - id
-            - message
-            - status_code
-            - airtel_money_id
+              example: "777503758"
+              description: Payee's identifier.
+        payeeNote:
+          type: string
+          example: "Payment for services"
+          description: Note from the payee.
+        status:
+          type: string
+          example: "TS"
+          description: Status of the transaction.
+
     merchantPaymentRequest:
       type: object
       properties:
@@ -219,12 +231,12 @@ components:
         payeeIdType:
           type: string
           example: "MSISDN"
-        sendAmount:
-          type: string
-          example: "150.00"
         sendCurrency:
           type: string
           example: "UGX"
+        receiveAmount:
+          type: string
+          example: "150.00"
         receiveCurrency:
           type: string
           example: "KES"
@@ -291,28 +303,28 @@ components:
             fspId:
               type: string
               example: "airtelzambia"
-            firstName:
+            name:
               type: string
               example: "Niza"
-            lastName:
-              type: string
-              example: "Tembo"
-            dateOfBirth:
-              type: string
-              example: "1997/09/04"
 
+        sendAmount:
+          type: string
+          example: "140.00"
+        sendCurrency:
+          type: string
+          example: "ZMW"
         receiveAmount:
           type: string
           example: "140.00"
         receiveCurrency:
           type: string
-          example: "EUR"
-        fees:
+          example: "MWK"
+        targetFees:
           type: string
           example: "10.00"
-        feeCurrency:
+        sourceFees:
           type: string
-          example: "USD"
+          example: "10.00"
         transactionId:
           type: string
           example: "42fdb186-2a36-46f1-9be9-8989a9e0aeb4"
@@ -335,19 +347,28 @@ components:
               type: string
               example: "Niza"
 
+        sendAmount:
+          type: string
+          example: "140.00"
+        sendCurrency:
+          type: string
+          example: "ZMW"
         receiveAmount:
           type: string
           example: "140.00"
         receiveCurrency:
           type: string
-          example: "EUR"
-        fees:
+          example: "MWK"
+        targetFees:
           type: string
           example: "10.00"
-        feeCurrency:
+        sourceFees:
           type: string
-          example: "USD"
+          example: "10.00"
         transactionId:
+          type: string
+          example: "01JKB0F2WV7YVSA6CXGP977XT9"
+        homeTransactionId:
           type: string
           example: "42fdb186-2a36-46f1-9be9-8989a9e0aeb4"
     sendMoneyRequest:
@@ -429,3 +450,9 @@ components:
         amount:
           type: string
           example: "500"
+        payerMessage:
+          type: string
+          example: "Payment for services"
+        payeeNote:
+          type: string
+          example: "Thank you!"

--- a/airtel-zm-core-connector/src/domain/CBSClient/types.ts
+++ b/airtel-zm-core-connector/src/domain/CBSClient/types.ts
@@ -412,11 +412,11 @@ export type TAirtelDisbursementResponse = {
 // Request coming from Airtel
 export type TAirtelSendMoneyRequest = {
     "homeTransactionId": string;
-    "amountType": "RECEIVE" | "SEND",
     "payeeId": string;
     "payeeIdType": components["schemas"]["PartyIdType"];
-    "sendAmount": string;
     "sendCurrency": components['schemas']['Currency'];
+    "sendAmount": string;
+    "receiveAmount": string;
     "receiveCurrency": components['schemas']['Currency'];
     "transactionDescription": string;
     "transactionType": components['schemas']['transferTransactionType'];
@@ -441,10 +441,12 @@ export type TAirtelSendMoneyResponse = {
         "fspId": string;
         "name":string;
       };
-    "receiveAmount": string;
-    "receiveCurrency": string;
-    "fees": string;
-    "feeCurrency": string;
+    "sendAmount": string,
+    "sendCurrency": string,
+    "receiveAmount": string,
+    "receiveCurrency": string,
+    "targetFees": string,
+    "sourceFees": string,
     "transactionId": string;
 }
 

--- a/airtel-zm-core-connector/src/domain/coreConnectorAgg.ts
+++ b/airtel-zm-core-connector/src/domain/coreConnectorAgg.ts
@@ -40,6 +40,7 @@ import {
     TCallbackRequest,
     TAirtelCollectMoneyResponse,
     TAirtelKycResponse,
+    TAirtelMerchantPaymentRequest,
 } from './CBSClient';
 import {
     ILogger,
@@ -362,7 +363,7 @@ export class CoreConnectorAggregate {
     //  Payer (These are used in the DFSP Core Connector Routes)
     // Send Transfer  -- (5)
 
-    async sendMoney(transfer: TAirtelSendMoneyRequest, amountType: "SEND" | "RECEIVE"): Promise<TAirtelSendMoneyResponse> {
+    async sendMoney(transfer: TAirtelSendMoneyRequest | TAirtelMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): Promise<TAirtelSendMoneyResponse> {
         this.logger.info(`Transfer from airtel account with ID${transfer.payer.payerId}`);
 
         const transferRequest: TSDKOutboundTransferRequest = await this.getTSDKOutboundTransferRequest(transfer, amountType);
@@ -439,7 +440,7 @@ export class CoreConnectorAggregate {
     }
 
     // Get TSDKOutbound Transfer Request DTO --(5.1) 
-    private async getTSDKOutboundTransferRequest(transfer: TAirtelSendMoneyRequest, amountType: "SEND" | "RECEIVE"): Promise<TSDKOutboundTransferRequest> {
+    private async getTSDKOutboundTransferRequest(transfer: TAirtelSendMoneyRequest | TAirtelMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): Promise<TSDKOutboundTransferRequest> {
         const res = await this.airtelClient.getKyc({
             msisdn: transfer.payer.payerId
         });
@@ -462,7 +463,7 @@ export class CoreConnectorAggregate {
             },
             'amountType': amountType,
             'currency': amountType === "SEND" ? transfer.sendCurrency : transfer.receiveCurrency,
-            'amount': transfer.sendAmount,
+            'amount': amountType === "SEND" ? transfer.sendAmount : transfer.receiveAmount,
             'transactionType': transfer.transactionType,
             'quoteRequestExtensions': this.getOutboundTransferExtensionList(transfer, amountType),
             'transferRequestExtensions': this.getOutboundTransferExtensionList(transfer, amountType)
@@ -470,28 +471,32 @@ export class CoreConnectorAggregate {
     }
 
     // Get OutBound Transfer Extension List DTO used in getTSDKOutboundTransferRequest DTO --(5.1.1)
-    private getOutboundTransferExtensionList(sendMoneyRequestPayload: TAirtelSendMoneyRequest, amountType: "SEND"| "RECEIVE"): TPayerExtensionListEntry[] | undefined {
+    private getOutboundTransferExtensionList(sendMoneyRequestPayload: TAirtelSendMoneyRequest | TAirtelMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): TPayerExtensionListEntry[] | undefined {
         if (sendMoneyRequestPayload.payer.DateAndPlaceOfBirth) {
             return [
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.BirthDt",
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.BirthDt",
                     "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.BirthDt
                 },
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.PrvcOfBirth",
-                    "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth ? "Not defined" : sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth
+                   "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.PrvcOfBirth",
+                    "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth ? sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.PrvcOfBirth : "Not defined"
                 },
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.CityOfBirth",
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.CityOfBirth",
                     "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.CityOfBirth
                 },
                 {
-                    "key": "CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.CtryOfBirth",
+                    "key": "CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.CtryOfBirth",
                     "value": sendMoneyRequestPayload.payer.DateAndPlaceOfBirth.CtryOfBirth
                 },
                 {
-                    "key":"CdtTrfTxInf.Purp.Cd",
-                    "value":amountType === "SEND" ? "MP2P" : "IPAY"
+                   "key": "CdtTrfTxInf.Dbtr.Nm",
+                    "value": sendMoneyRequestPayload.payer.name
+                },
+                {
+                    "key": "CdtTrfTxInf.Purp.Cd",
+                    "value": amountType === "SEND" ? "MP2P" : "IPAY"
                 }
             ];
         }
@@ -506,14 +511,30 @@ export class CoreConnectorAggregate {
                 "idType": transfer.to.idType,
                 "idValue": transfer.to.idValue,
                 "fspId": transfer.to.fspId !== undefined ? transfer.to.fspId : "No FSP ID Returned",
-                "name": transfer.getPartiesResponse?.body.party.name !== undefined ? transfer.getPartiesResponse?.body.party.name: ""
-            },
+                "name": transfer.getPartiesResponse?.body.party.name !== undefined ? transfer.getPartiesResponse?.body.party.name : ""
+                },
+            "sendAmount": transfer.fxQuoteResponse?.body.conversionTerms.sourceAmount.amount !== undefined ? transfer.fxQuoteResponse.body.conversionTerms.sourceAmount.amount : "No send amount ",
+            "sendCurrency": transfer.fxQuoteResponse?.body.conversionTerms.sourceAmount.currency !== undefined ? transfer.fxQuoteResponse.body.conversionTerms.sourceAmount.currency : "No send currency ",
             "receiveAmount": transfer.quoteResponse?.body.payeeReceiveAmount?.amount !== undefined ? transfer.quoteResponse.body.payeeReceiveAmount.amount : "No payee receive amount",
             "receiveCurrency": transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency !== undefined ? transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency : "No Currency returned from Mojaloop Connector",
-            "fees": transfer.quoteResponse?.body.payeeFspFee?.amount !== undefined ? transfer.quoteResponse?.body.payeeFspFee?.amount : "No fee amount returned from Mojaloop Connector",
-            "feeCurrency": transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency !== undefined ? transfer.fxQuoteResponse?.body.conversionTerms.targetAmount.currency : "No Fee currency retrned from Mojaloop Connector",
+            "targetFees": this.getQuoteCharges(transfer),
+            "sourceFees": this.getFxQuoteResponseCharges(transfer),
+            
             "transactionId": transfer.transferId !== undefined ? transfer.transferId : "No transferId returned",
         };
+    }
+
+    private getQuoteCharges(transferRes: TSDKOutboundTransferResponse): string {
+        return parseFloat(transferRes.quoteResponse?.body.payeeFspFee?.amount ?? "0").toString();
+    }
+
+    private getFxQuoteResponseCharges(data: TSDKOutboundTransferResponse): string {
+        if (data.fxQuoteResponse && data.fxQuoteResponse.body.conversionTerms.charges) {
+            return data.fxQuoteResponse.body.conversionTerms.charges.reduce((total, charge) => {
+                return total + parseFloat(charge.sourceAmount !== undefined ? charge.sourceAmount.amount : "0");
+            }, 0).toString();
+        }
+        return "0";
     }
 
     // Validation of Conversion Terms --(5.1)

--- a/airtel-zm-core-connector/test/fixtures.ts
+++ b/airtel-zm-core-connector/test/fixtures.ts
@@ -338,9 +338,8 @@ export const transferRequestDto = (idType: string, idValue: string, amount: stri
 
 // Send Money DTO
 
-export const sendMoneyMerchantPaymentDTO = (idValue: string, amount: string, amountType: "RECEIVE" | "SEND"): TAirtelSendMoneyRequest => ({
+export const sendMoneyMerchantPaymentDTO = (idValue: string, amount: string): TAirtelSendMoneyRequest => ({
   "homeTransactionId": "HTX123456789",
-  "amountType": amountType,
   "payeeId": "07676767676",
   "payeeIdType": "MSISDN",
   "sendAmount": amount,
@@ -358,7 +357,7 @@ export const sendMoneyMerchantPaymentDTO = (idValue: string, amount: string, amo
       CtryOfBirth: "Lusaka",
     },
   },
-
+  receiveAmount: ''
 });
 
 

--- a/airtel-zm-core-connector/test/unit/domain/coreConnectorAgg.test.ts
+++ b/airtel-zm-core-connector/test/unit/domain/coreConnectorAgg.test.ts
@@ -46,8 +46,6 @@ const SDK_URL = 'http://localhost:4010';
 const idType = "MSISDN";
 const MSISDN_NO = "971938765";
 
-
-
 describe('CoreConnectorAggregate Tests -->', () => {
     let ccAggregate: CoreConnectorAggregate;
     let airtelClient: IAirtelClient;
@@ -255,7 +253,7 @@ describe('CoreConnectorAggregate Tests -->', () => {
             // Spying on Initiate transfer
             const initiateTransferSpy = jest.spyOn(sdkClient, "initiateTransfer");
 
-            const sendMoneyRequestBody = sendMoneyMerchantPaymentDTO(MSISDN_NO, "1000", "SEND");
+            const sendMoneyRequestBody = sendMoneyMerchantPaymentDTO(MSISDN_NO, "1000");
             const res = await ccAggregate.sendMoney(sendMoneyRequestBody, "SEND");
 
             logger.info("Response from send money", res);
@@ -272,7 +270,7 @@ describe('CoreConnectorAggregate Tests -->', () => {
             // Check the Extension List is not 0
             expect(transferRequest.quoteRequestExtensions).not.toHaveLength(0);
             if (transferRequest.quoteRequestExtensions) {
-                expect(transferRequest.quoteRequestExtensions[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.BirthDt");
+                expect(transferRequest.quoteRequestExtensions[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.BirthDt");
             }
             logger.info("Trasnfer REquest  being sent to Initiate Transfer", transferRequest);
 
@@ -340,7 +338,7 @@ describe('CoreConnectorAggregate Tests -->', () => {
             jest.spyOn(sdkClient, "updateTransfer");
 
             const initiateTransferSpy = jest.spyOn(sdkClient, "initiateTransfer");
-            const merchantPaymentRequestBody = sendMoneyMerchantPaymentDTO(MSISDN_NO, "1000", "RECEIVE");
+            const merchantPaymentRequestBody = sendMoneyMerchantPaymentDTO(MSISDN_NO, "1000");
             const res = await ccAggregate.sendMoney(merchantPaymentRequestBody, "RECEIVE");
 
             logger.info("Response from merchant payment", res);
@@ -359,7 +357,7 @@ describe('CoreConnectorAggregate Tests -->', () => {
             // Check the Extension List is not 0
             expect(transferRequest.quoteRequestExtensions).not.toHaveLength(0);
             if (transferRequest.quoteRequestExtensions) {
-                expect(transferRequest.quoteRequestExtensions[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.PrvtId.DtAndPlcOfBirth.BirthDt");
+                expect(transferRequest.quoteRequestExtensions[0]["key"]).toEqual("CdtTrfTxInf.Dbtr.Id.PrvtId.DtAndPlcOfBirth.BirthDt");
             }
             logger.info("Trasnfer REquest  being sent to Initiate Transfer", transferRequest);
         });


### PR DESCRIPTION
- Refactored send-money response in api spec body.
- Refactored merchant-payment request to specify receiveAmount and not sendAmount.
- Refactored merchant-payment response.
- Refactored the getTSDKOutboundTransferRequest DTO to dynamically specify the sendAmount or receiveAmount depending on whether the request is a merchant payment or send money.
- Fixed the ISO20022 Paths in getOutboundTransferExtensionList DTO to include Id and name