### PR TITLE
feat: application of fixes and updates to nbm core connector 

### DIFF
--- a/zicb-zm-core-connector/src/domain/coreConnectorAgg.ts
+++ b/zicb-zm-core-connector/src/domain/coreConnectorAgg.ts
@@ -429,7 +429,7 @@ export class CoreConnectorAggregate implements ICoreConnectorAggregate {
     async sendMoney(transfer: TZicbSendMoneyRequest | TZicbMerchantPaymentRequest, amountType: "SEND" | "RECEIVE"): Promise<TZicbSendMoneyResponse> {
         this.logger.info(`Received send money request for payer with ID ${transfer.payer.payerId}`);
 
-        const transferRequest: TSDKOutboundTransferRequest = await this.getTSDKOutboundTransferRequest(transfer, amountType)
+        const transferRequest: TSDKOutboundTransferRequest = await this.getTSDKOutboundTransferRequest(transfer, amountType);
         const res = await this.sdkClient.initiateTransfer(transferRequest);
         
         if (res.data.currentState === "WAITING_FOR_CONVERSION_ACCEPTANCE") {


### PR DESCRIPTION
the send-money response was edited in the api spec. Also the merchant-payment request body was changed to spedicify the recieveAmount and not sendAmount. The getTSDKOutboundTransferRequest DTO was refactored to dynamically specify the sendAmount or receiveAmount depending on whether the request is a merchant payment or send money. The ISO20022 paths were fixed in the getOutboundTransferExtensionList DTO to include ID and name. The unit tests were refactored to conform to the updated request bodies.